### PR TITLE
Rename multi-call binary from `sed` to `sedapp` & enable ignored test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.0.1"
 authors = ["uutils developers"]
 license = "MIT"
 description = "sed ~ implemented as universal (cross-platform) utils, written in Rust"
-default-run = "sed"
+default-run = "sedapp"
 
 homepage = "https://github.com/uutils/sed"
 repository = "https://github.com/uutils/sed"
@@ -79,8 +79,8 @@ phf_codegen = { workspace = true }
 
 
 [[bin]]
-name = "sed"
-path = "src/bin/sed.rs"
+name = "sedapp"
+path = "src/bin/sedapp.rs"
 
 [[bin]]
 name = "uudoc"

--- a/src/bin/sedapp.rs
+++ b/src/bin/sedapp.rs
@@ -140,7 +140,7 @@ fn gen_completions<T: uucore::Args>(
     args: impl Iterator<Item = OsString>,
     util_map: &UtilityMap<T>,
 ) -> ! {
-    let all_utilities: Vec<_> = std::iter::once("sed")
+    let all_utilities: Vec<_> = std::iter::once("sedapp")
         .chain(util_map.keys().copied())
         .collect();
 
@@ -161,7 +161,7 @@ fn gen_completions<T: uucore::Args>(
     let utility = matches.get_one::<String>("utility").unwrap();
     let shell = *matches.get_one::<Shell>("shell").unwrap();
 
-    let mut command = if utility == "sed" {
+    let mut command = if utility == "sedapp" {
         gen_sed_app(util_map)
     } else {
         util_map.get(utility).unwrap().1()
@@ -178,7 +178,7 @@ fn gen_manpage<T: uucore::Args>(
     args: impl Iterator<Item = OsString>,
     util_map: &UtilityMap<T>,
 ) -> ! {
-    let all_utilities: Vec<_> = std::iter::once("sed")
+    let all_utilities: Vec<_> = std::iter::once("sedapp")
         .chain(util_map.keys().copied())
         .collect();
 
@@ -193,7 +193,7 @@ fn gen_manpage<T: uucore::Args>(
 
     let utility = matches.get_one::<String>("utility").unwrap();
 
-    let command = if utility == "sed" {
+    let command = if utility == "sedapp" {
         gen_sed_app(util_map)
     } else {
         util_map.get(utility).unwrap().1()
@@ -207,7 +207,7 @@ fn gen_manpage<T: uucore::Args>(
 }
 
 fn gen_sed_app<T: uucore::Args>(util_map: &UtilityMap<T>) -> Command {
-    let mut command = Command::new("sed");
+    let mut command = Command::new("sedapp");
     for (name, (_, sub_app)) in util_map {
         // Recreate a small subcommand with only the relevant info
         // (name & short description)

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -21,7 +21,6 @@ fn test_silent_alias() {
 }
 
 #[test]
-#[ignore = "not implemented yet"]
 fn test_missing_script_argument() {
     new_ucmd!()
         .fails()

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -45,7 +45,7 @@ static MULTIPLE_STDIN_MEANINGLESS: &str = "Ucommand is designed around a typical
 
 static NO_STDIN_MEANINGLESS: &str = "Setting this flag has no effect if there is no stdin";
 
-pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_sed");
+pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_sedapp");
 pub const PATH: &str = env!("PATH");
 
 /// Default environment variables to run the commands with


### PR DESCRIPTION
This PR renames the multi-call binary from `sed` to `sedapp` in order to distinguish between the multi-call binary and the `sed` util. This change also allows us to re-enable the ignored test.

I'm not sure about the name `sedapp`, it's just the first name that came to my mind ;-)