### PR TITLE
Remove unmaintained `atty`, use `std::io::IsTerminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,17 +77,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,15 +298,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -690,7 +670,6 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 name = "sed"
 version = "0.0.1"
 dependencies = [
- "atty",
  "chrono",
  "clap",
  "clap_complete",
@@ -888,7 +867,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "uu_sed"
 version = "0.0.1"
 dependencies = [
- "atty",
  "clap",
  "memmap2",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ feat_common_core = [
 ]
 
 [workspace.dependencies]
-atty = "0.2"
 bytesize = "2.0.0"
 chrono = { version = "0.4.37", default-features = false, features = [
   "clock",
@@ -52,7 +51,6 @@ xattr = "1.3.1"
 
 
 [dependencies]
-atty = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }

--- a/src/uu/sed/Cargo.toml
+++ b/src/uu/sed/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["command-line-utilities"]
 
 
 [dependencies]
-atty = { workspace = true }
 clap = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }

--- a/src/uu/sed/src/processor.rs
+++ b/src/uu/sed/src/processor.rs
@@ -15,8 +15,8 @@ use crate::command::{
 use crate::fast_io::{IOChunk, LineReader, OutputBuffer};
 use crate::in_place::InPlace;
 use crate::named_writer;
-use atty::Stream;
 use std::cell::RefCell;
+use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 use std::rc::Rc;
 use uucore::error::{UResult, USimpleError};
@@ -476,7 +476,7 @@ pub fn process_all_files(
     files: Vec<PathBuf>,
     mut context: ProcessingContext,
 ) -> UResult<()> {
-    context.unbuffered = context.unbuffered || atty::is(Stream::Stdout);
+    context.unbuffered = context.unbuffered || io::stdout().is_terminal();
 
     let mut in_place = InPlace::new(context.clone())?;
     let last_file_index = files.len() - 1;


### PR DESCRIPTION
This PR removes the unmaintained `atty` and uses `std::io::IsTerminal` instead. It fixes https://github.com/advisories/GHSA-g98v-hv3f-hcfr