### PR TITLE
ci: remove `crossbeam-epoch` workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,6 @@ jobs:
       run: |
         git clone https://github.com/mozilla/grcov.git ~/grcov/
         cd ~/grcov
-        # Hardcode the version of crossbeam-epoch. See
-        # https://github.com/uutils/coreutils/issues/3680
-        sed -i -e "s|tempfile =|crossbeam-epoch = \"=0.9.8\"\ntempfile =|" Cargo.toml
         cargo install --path .
         cd -
 # Uncomment when the upstream issue


### PR DESCRIPTION
This PR removes a workaround with a hard-coded version of `crossbeam-epoch`.