### PR TITLE
clippy: fix warnings introduced with Rust `1.89`

### DIFF
--- a/src/uu/sed/src/fast_io.rs
+++ b/src/uu/sed/src/fast_io.rs
@@ -407,7 +407,7 @@ impl LineReader {
 
     /// Return the next line, if available and also the availability
     /// of another one, or None at end of file.
-    pub fn get_line(&mut self) -> io::Result<Option<(IOChunk, bool)>> {
+    pub fn get_line(&mut self) -> io::Result<Option<(IOChunk<'_>, bool)>> {
         match self {
             #[cfg(unix)]
             LineReader::MmapInput { cursor, .. } => {

--- a/src/uu/sed/src/processor.rs
+++ b/src/uu/sed/src/processor.rs
@@ -660,14 +660,15 @@ fn process_file(
     }
 
     // Handle any N command remains.
-    if context.separate && !context.quiet {
-        if let Some(action) = context.input_action.take() {
-            let mut pending = action.prepend;
-            pending.push('\n');
-            output.write_str(pending)?;
-            if context.unbuffered {
-                output.flush()?;
-            }
+    if context.separate
+        && !context.quiet
+        && let Some(action) = context.input_action.take()
+    {
+        let mut pending = action.prepend;
+        pending.push('\n');
+        output.write_str(pending)?;
+        if context.unbuffered {
+            output.flush()?;
         }
     }
 
@@ -698,12 +699,14 @@ pub fn process_all_files(
         process_file(&commands, &mut reader, output, context)?;
 
         // Handle any N command remains.
-        if context.last_file && !context.separate && !context.quiet {
-            if let Some(action) = context.input_action.take() {
-                let mut pending = action.prepend;
-                pending.push('\n');
-                output.write_str(pending)?;
-            }
+        if context.last_file
+            && !context.separate
+            && !context.quiet
+            && let Some(action) = context.input_action.take()
+        {
+            let mut pending = action.prepend;
+            pending.push('\n');
+            output.write_str(pending)?;
         }
 
         in_place.end()?;


### PR DESCRIPTION
This PR fixes clippy warnings introduced with Rust `1.89`. One warning is related to the [mismatched lifetime syntaxes lint](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint) described in the announcement. The other warnings are related to the [collapsible_if](https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if) lint.