### PR TITLE
Reorder s/// struct elements for readability

### DIFF
--- a/src/uu/sed/src/command.rs
+++ b/src/uu/sed/src/command.rs
@@ -206,13 +206,12 @@ impl ReplacementTemplate {
 #[derive(Debug, Default)]
 /// Substitution command
 pub struct Substitution {
-    pub occurrence: usize, // Which occurrence to substitute
-    pub print_flag: bool,  // True if 'p' flag
-    pub ignore_case: bool, // True if 'I' flag
+    pub regex: Option<Regex>,                         // Regular expression
+    pub replacement: ReplacementTemplate,             // Specified broken-down replacement
+    pub occurrence: usize,                            // Which occurrence to substitute
+    pub print_flag: bool,                             // True if 'p' flag
+    pub ignore_case: bool,                            // True if 'I' flag
     pub write_file: Option<Rc<RefCell<NamedWriter>>>, // Writer to file if 'w' flag is used
-    pub regex: Option<Regex>, // Regular expression
-    pub line_number: usize, // Line number
-    pub replacement: ReplacementTemplate, // Specified broken-down replacement
 }
 
 /// The block of the first and most common Unicode characters:

--- a/src/uu/sed/src/compiler.rs
+++ b/src/uu/sed/src/compiler.rs
@@ -706,10 +706,7 @@ fn compile_subst_command(
 
     let pattern = parse_regex(lines, line)?;
 
-    let mut subst = Box::new(Substitution {
-        line_number: lines.get_line_number(),
-        ..Default::default()
-    });
+    let mut subst = Box::new(Substitution::default());
 
     subst.replacement = compile_replacement(lines, line)?;
     compile_subst_flags(lines, line, &mut subst)?;


### PR DESCRIPTION
Make their order match how they are specified.
While at it remove unused line_number field.