### PR TITLE
Cargo.toml: Remove non standard profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,18 +114,13 @@ lto = true
 [profile.release-fast]
 inherits = "release"
 panic = "abort"
-codegen-units = 1
+codegen-units = 1 # should be moved to release without regression
 
 # A release-like profile that is as small as possible.
 [profile.release-small]
 inherits = "release-fast"
 opt-level = "z"
 strip = true
-
-# The profile that 'cargo dist' will build with
-[profile.dist]
-inherits = "release"
-lto = "thin"
 
 [lints.clippy]
 default_trait_access = "warn"


### PR DESCRIPTION
release has lto=true. Undocumented profile. release{,-fast} is enough.