### PR TITLE
fix spurious failure in run-gnu-testsuite.sh

### DIFF
--- a/util/run-gnu-testsuite.sh
+++ b/util/run-gnu-testsuite.sh
@@ -239,9 +239,11 @@ run_sed_test() {
     local rust_exit_code=0
     local rust_output=""
     if [[ -n "$flags" ]]; then
-        rust_output=$("$RUST_SED_BIN" "$flags" "$sed_script" input.txt 2>/dev/null) || rust_exit_code=$?
+        # shellcheck disable=SC2086
+        rust_output=$("$RUST_SED_BIN" "$flags" $sed_script input.txt 2> /dev/null) || rust_exit_code=$?
     else
-        rust_output=$(echo -n "$input_text" | "$RUST_SED_BIN" "$sed_script" 2>/dev/null) || rust_exit_code=$?
+        # shellcheck disable=SC2086
+        rust_output=$(echo -n "$input_text" | "$RUST_SED_BIN" $sed_script 2> /dev/null) || rust_exit_code=$?
     fi
 
     local test_result=""


### PR DESCRIPTION
- correct input and expected output strings
  use ANSI-C strings to interpret `\n`
- unquote sed_script

https://github.com/uutils/sed/blob/c6479b44ad05b71fd699b059ae1e32fa69e738aa/util/run-gnu-testsuite.sh#L304

requires to unquote options:

```diff
--- main
+++ this PR
- ./target/release/sed -n '-n 2p' input.txt
+ ./target/release/sed -n -n 2p input.txt
```

Note that `print_line` still fails due to multiple `-n`.