### PR TITLE
Fix incorrect rejection of multiple usage of same CLI argument

### DIFF
--- a/src/sed/mod.rs
+++ b/src/sed/mod.rs
@@ -382,6 +382,14 @@ mod tests {
     }
 
     #[test]
+    fn test_multiple_same_arguments() {
+        let matches = test_matches(&["-E", "-r"]);
+        let ctx = build_context(&matches);
+
+        assert!(ctx.regex_extended);
+    }
+
+    #[test]
     fn test_in_place_with_suffix() {
         let matches = test_matches(&["-i", ".bak"]);
         let ctx = build_context(&matches);


### PR DESCRIPTION
Fixes [issue 250](https://github.com/uutils/sed/issues/250)

Previously, using an argument more than 1 time regardless if it was the short, long or alias format, resulted in an error. This was caused due to the `clap`'s default way of working. Adding `.args_override_self(true)` to the Command instance solves the problem.