### PR TITLE
Fix incomplete text command

### DIFF
--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -2726,6 +2726,19 @@ mod tests {
     }
 
     #[test]
+    fn test_compile_text_command_posix_incomplete() {
+        let (mut lines, mut chars) = make_providers("i\\");
+        let mut cmd = Command::default();
+        let mut context = ProcessingContext {
+            posix: true,
+            ..Default::default()
+        };
+        let result = compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context);
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("incomplete command"));
+    }
+
+    #[test]
     fn test_compile_text_command_gnu_optional_backslash() {
         let mut chars = make_char_provider("athere");
         let mut lines = make_line_provider(&["line1", "line2"]);

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -1067,6 +1067,15 @@ fn test_undefined_label() {
 }
 
 #[test]
+fn test_incomplete_test_command_posix() {
+    new_ucmd!()
+        .args(&["--posix", "i\\"])
+        .fails()
+        .code_is(1)
+        .stderr_is("sed: :0:3: error: incomplete command\n");
+}
+
+#[test]
 fn test_addr0_non_posix() {
     new_ucmd!()
         .args(&["--posix", "0,/foo/p"])


### PR DESCRIPTION
Fixes [issue 251](https://github.com/uutils/sed/issues/251)

Incomplete text commands (`a`, `c`, `i`) in POSIX mode, now result in compilation error.