### PR TITLE
Improve GNU sed testsuite compatibility

### DIFF
--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -27,7 +27,9 @@ use std::rc::Rc;
 use terminal_size::{Width, terminal_size};
 use uucore::error::{UResult, USimpleError};
 
-const DEFAULT_OUTPUT_WIDTH: usize = 60;
+/// Default line-wrap width for the `l` command when no terminal, COLS, or
+/// `-l` flag is available.  Matches GNU sed's compiled-in default of 70.
+const DEFAULT_OUTPUT_WIDTH: usize = 70;
 
 // Handling required after processing a command
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -252,8 +254,10 @@ fn compile_sequence(
 
         // According to POSIX: "If the first two characters in the script are
         // "#n", the default output shall be suppressed".
+        // This only applies to the very first line of the first script source.
         if !line.eol()
             && line.current() == '#'
+            && lines.get_source_index() == 0
             && lines.get_line_number() == 1
             && line.get_pos() == 0
         {
@@ -511,25 +515,33 @@ fn parse_number(
 }
 
 /// Parse the end of a command, failing with an error on extra characters.
+/// Valid command terminators are: EOL, ';', '}', and '#' (start of comment).
 fn parse_command_ending(
     lines: &ScriptLineProvider,
     line: &mut ScriptCharProvider,
     cmd: &mut Command,
 ) -> UResult<()> {
-    if !line.eol() && line.current() == ';' {
-        line.advance();
+    line.eat_spaces();
+
+    if line.eol() {
         return Ok(());
     }
 
-    if !line.eol() {
-        return compilation_error(
+    match line.current() {
+        ';' => {
+            line.advance();
+            Ok(())
+        }
+        '}' | '#' => {
+            // Don't consume — the caller (compile_sequence) handles these
+            Ok(())
+        }
+        _ => compilation_error(
             lines,
             line,
             format!("extra characters at the end of the {} command", cmd.code),
-        );
+        ),
     }
-
-    Ok(())
 }
 
 /// Convert a primitive BRE pattern to a safe ERE-compatible pattern string.
@@ -710,7 +722,7 @@ pub fn compile_replacement(
                             if let Some(decoded) = parse_char_escape(line) {
                                 literal.push(decoded);
                             } else {
-                                literal.push('\\');
+                                // Unknown escape: drop the backslash (GNU behavior)
                                 literal.push(line.current());
                                 line.advance();
                             }
@@ -931,6 +943,8 @@ pub fn compile_subst_flags(
 
             ';' | '\n' => break,
 
+            '}' | '#' => break, // closing brace and comment start are valid terminators
+
             other => {
                 return compilation_error(
                     lines,
@@ -1068,7 +1082,16 @@ fn compile_label_command(
 }
 
 /// Return the width of the command's terminal or a default.
+/// GNU sed checks COLS env var first, then terminal width, then defaults to 70.
+/// COLS values <= 0 or non-numeric are ignored.
 fn output_width() -> usize {
+    if let Ok(cols) = std::env::var("COLS")
+        && let Ok(n) = cols.parse::<usize>()
+        && n > 0
+    {
+        // Subtract 1 to avoid line wraps on terminals
+        return n - 1;
+    }
     if let Some((Width(w), _)) = terminal_size() {
         w as usize
     } else {
@@ -1082,13 +1105,17 @@ fn compile_number_command(
     lines: &mut ScriptLineProvider,
     line: &mut ScriptCharProvider,
     cmd: &mut Command,
-    _context: &mut ProcessingContext,
+    context: &mut ProcessingContext,
 ) -> UResult<CommandHandling> {
     line.advance(); // Skip the command character
     line.eat_spaces(); // Skip any leading whitespace
 
     match parse_number(lines, line, false)? {
         Some(n) => {
+            // 'l<N>' is a GNU extension, reject in POSIX mode
+            if cmd.code == 'l' && context.posix {
+                return compilation_error(lines, line, "extra characters after command");
+            }
             cmd.data = CommandData::Number(n);
         }
         None => match cmd.code {
@@ -1096,7 +1123,13 @@ fn compile_number_command(
                 cmd.data = CommandData::Number(0);
             }
             'l' => {
-                cmd.data = CommandData::Number(output_width());
+                // Use -l flag value if set (non-zero), else auto-detect
+                let width = if context.length > 0 {
+                    context.length
+                } else {
+                    output_width()
+                };
+                cmd.data = CommandData::Number(width);
             }
             _ => panic!("invalid number-expecting command"),
         },
@@ -1438,7 +1471,7 @@ mod tests {
         let err = result.unwrap_err();
         let msg = err.to_string();
 
-        assert!(msg.contains("test.sed:42:5: error: unexpected token"));
+        assert!(msg.contains("test.sed:42: unexpected token"));
     }
 
     #[test]
@@ -1455,7 +1488,7 @@ mod tests {
         let err = result.unwrap_err();
         let msg = err.to_string();
 
-        assert_eq!(msg, "input.txt:3:1: error: invalid command 'x'");
+        assert_eq!(msg, "input.txt:3: invalid command 'x'");
     }
 
     // get_verified_cmd_spec
@@ -1467,7 +1500,7 @@ mod tests {
 
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("test.sed:1:1: error: command expected"));
+        assert!(msg.contains("test.sed:1: command expected"));
     }
 
     #[test]
@@ -1478,7 +1511,7 @@ mod tests {
 
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("script.sed:2:1: error: invalid command code `@'"));
+        assert!(msg.contains("script.sed:2: invalid command code `@'"));
     }
 
     #[test]
@@ -1489,9 +1522,7 @@ mod tests {
 
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("input.sed:3:1: error: command q expects up to 1 address(es), found 2")
-        );
+        assert!(msg.contains("input.sed:3: command q expects up to 1 address(es), found 2"));
     }
 
     #[test]
@@ -1511,9 +1542,7 @@ mod tests {
         let result = get_verified_cmd_spec(&lines, &line, 2, true);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("input.sed:1:1: error: command i expects up to 1 address(es), found 2")
-        );
+        assert!(msg.contains("input.sed:1: command i expects up to 1 address(es), found 2"));
     }
 
     // parse_number
@@ -1892,7 +1921,7 @@ mod tests {
 
         assert_eq!(cmd.location.line_number, 1);
         assert_eq!(cmd.location.column_number, 1);
-        assert_eq!(cmd.location.input_name.as_ref(), "<script argument 1>");
+        assert_eq!(cmd.location.input_name.as_ref(), "-e expression #1");
 
         assert!(cmd.next.is_none());
     }
@@ -1909,14 +1938,14 @@ mod tests {
         assert_eq!(cmd.code, 'l');
         assert_eq!(cmd.location.line_number, 1);
         assert_eq!(cmd.location.column_number, 1);
-        assert_eq!(cmd.location.input_name.as_ref(), "<script argument 1>");
+        assert_eq!(cmd.location.input_name.as_ref(), "-e expression #1");
 
         let binding2 = cmd.next.clone().unwrap();
         let cmd2 = binding2.borrow();
         assert_eq!(cmd2.code, 'q');
         assert_eq!(cmd2.location.line_number, 1);
         assert_eq!(cmd2.location.column_number, 3);
-        assert_eq!(cmd2.location.input_name.as_ref(), "<script argument 1>");
+        assert_eq!(cmd2.location.input_name.as_ref(), "-e expression #1");
 
         assert!(cmd2.next.is_none());
     }

--- a/src/sed/error_handling.rs
+++ b/src/sed/error_handling.rs
@@ -47,36 +47,53 @@ impl ScriptLocation {
 
 /// Fail with msg as a compile error at the provider location.
 /// The error's exit code is 1 (compilation phase).
+/// Format matches GNU sed: `-e expression #N, char C: message` for string
+/// scripts, `file:line: message` for file scripts.
 pub fn compilation_error<T>(
     lines: &ScriptLineProvider,
     line: &ScriptCharProvider,
     msg: impl ToString,
 ) -> UResult<T> {
-    Err(USimpleError::new(
-        1,
+    let input_name = lines.get_input_name();
+    let message = if input_name.starts_with("-e expression") {
+        // GNU format: char position is 1-based within the current line
         format!(
-            "{}:{}:{}: error: {}",
-            lines.get_input_name(),
-            lines.get_line_number(),
+            "{}, char {}: {}",
+            input_name,
             line.get_pos() + 1,
             msg.to_string()
-        ),
-    ))
+        )
+    } else {
+        format!(
+            "{}:{}: {}",
+            input_name,
+            lines.get_line_number(),
+            msg.to_string()
+        )
+    };
+    Err(USimpleError::new(1, message))
 }
 
 /// Fail with msg as a compilation error at the command's location.
 /// The error's exit code is as specified.
+/// Format matches GNU sed conventions.
 fn location_error<T>(location: &ScriptLocation, msg: impl ToString, exit_code: i32) -> UResult<T> {
-    Err(USimpleError::new(
-        exit_code,
+    let message = if location.input_name.starts_with("-e expression") {
         format!(
-            "{}:{}:{}: error: {}",
+            "{}, char {}: {}",
             location.input_name,
-            location.line_number,
             location.column_number,
             msg.to_string()
-        ),
-    ))
+        )
+    } else {
+        format!(
+            "{}:{}: {}",
+            location.input_name,
+            location.line_number,
+            msg.to_string()
+        )
+    };
+    Err(USimpleError::new(exit_code, message))
 }
 
 /// Fail with msg as a compilation error at the command's location.
@@ -101,13 +118,16 @@ pub fn input_runtime_error<T>(
     context: &ProcessingContext,
     msg: impl ToString,
 ) -> UResult<T> {
+    let loc_str = if location.input_name.starts_with("-e expression") {
+        format!("{}, char {}", location.input_name, location.column_number)
+    } else {
+        format!("{}:{}", location.input_name, location.line_number)
+    };
     Err(USimpleError::new(
         2,
         format!(
-            "{}:{}:{}: {}:{} error: {}",
-            location.input_name,
-            location.line_number,
-            location.column_number,
+            "{}: {}:{} error: {}",
+            loc_str,
             context.input_name,
             context.line_number,
             msg.to_string()

--- a/src/sed/mod.rs
+++ b/src/sed/mod.rs
@@ -194,7 +194,9 @@ fn build_context(matches: &ArgMatches) -> ProcessingContext {
         in_place_suffix: matches
             .get_one::<String>("in-place")
             .and_then(|s| if s.is_empty() { None } else { Some(s.clone()) }),
-        length: matches.get_one::<u32>("length").map_or(70, |v| *v as usize),
+        // 0 means "not explicitly set via -l"; the l command then
+        // falls back to COLS, terminal width, or DEFAULT_OUTPUT_WIDTH.
+        length: matches.get_one::<u32>("length").map_or(0, |v| *v as usize),
         quiet: matches.get_flag("quiet"),
         posix: matches.get_flag("posix"),
         separate: matches.get_flag("separate"),
@@ -334,7 +336,7 @@ mod tests {
         assert!(!ctx.follow_symlinks);
         assert!(!ctx.in_place);
         assert_eq!(ctx.in_place_suffix, None);
-        assert_eq!(ctx.length, 70);
+        assert_eq!(ctx.length, 0);
         assert!(!ctx.quiet);
         assert!(!ctx.posix);
         assert!(!ctx.separate);
@@ -403,7 +405,7 @@ mod tests {
         let ctx_default = build_context(&matches_default);
         let ctx_custom = build_context(&matches_custom);
 
-        assert_eq!(ctx_default.length, 70);
+        assert_eq!(ctx_default.length, 0);
         assert_eq!(ctx_custom.length, 120);
     }
 }

--- a/src/sed/script_line_provider.rs
+++ b/src/sed/script_line_provider.rs
@@ -60,6 +60,14 @@ impl ScriptLineProvider {
         }
     }
 
+    /// Return the zero-based index of the currently processed script source.
+    pub fn get_source_index(&self) -> usize {
+        match &self.state {
+            State::Active { index, .. } => *index,
+            _ => 0,
+        }
+    }
+
     /// Return the currently processed script descriptive name.
     pub fn get_input_name(&self) -> &str {
         match &self.state {
@@ -118,7 +126,7 @@ impl ScriptLineProvider {
                 self.state = State::Active {
                     index: next_index,
                     reader: Box::new(BufReader::new(cursor)),
-                    input_name: format!("<script argument {}>", next_index + 1),
+                    input_name: format!("-e expression #{}", next_index + 1),
                     line_number: 0,
                 };
             }
@@ -268,7 +276,7 @@ mod tests {
         if let Some(line) = provider.next_line().unwrap() {
             assert_eq!(line.trim(), "l1");
             assert_eq!(provider.get_line_number(), 1);
-            assert_eq!(provider.get_input_name(), "<script argument 1>");
+            assert_eq!(provider.get_input_name(), "-e expression #1");
         } else {
             panic!("Expected a line");
         }
@@ -276,7 +284,7 @@ mod tests {
         if let Some(line) = provider.next_line().unwrap() {
             assert_eq!(line.trim(), "l2");
             assert_eq!(provider.get_line_number(), 2);
-            assert_eq!(provider.get_input_name(), "<script argument 1>");
+            assert_eq!(provider.get_input_name(), "-e expression #1");
         } else {
             panic!("Expected a line");
         }
@@ -284,7 +292,7 @@ mod tests {
         if let Some(line) = provider.next_line().unwrap() {
             assert_eq!(line.trim(), "l3");
             assert_eq!(provider.get_line_number(), 1);
-            assert_eq!(provider.get_input_name(), "<script argument 2>");
+            assert_eq!(provider.get_input_name(), "-e expression #2");
         } else {
             panic!("Expected a line");
         }

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -1071,7 +1071,7 @@ fn test_invalid_backreference() {
         .args(&["-n", "-e", r"s/./X/;s//\1/", LINES1])
         .fails()
         .code_is(2)
-        .stderr_is("sed: <script argument 1>:1:8: error: invalid reference \\1 on command's RHS\n");
+        .stderr_is("sed: -e expression #1, char 8: invalid reference \\1 on command's RHS\n");
 }
 
 #[test]
@@ -1080,7 +1080,7 @@ fn test_duplicate_label() {
         .args(&[":foo;:foo"])
         .fails()
         .code_is(1)
-        .stderr_is("sed: <script argument 1>:1:6: error: duplicate label `foo'\n");
+        .stderr_is("sed: -e expression #1, char 6: duplicate label `foo'\n");
 }
 
 #[test]
@@ -1089,7 +1089,7 @@ fn test_undefined_label() {
         .args(&["b foo"])
         .fails()
         .code_is(1)
-        .stderr_is("sed: <script argument 1>:1:1: error: undefined label `foo'\n");
+        .stderr_is("sed: -e expression #1, char 1: undefined label `foo'\n");
 }
 
 #[test]
@@ -1098,7 +1098,7 @@ fn test_incomplete_test_command_posix() {
         .args(&["--posix", "i\\"])
         .fails()
         .code_is(1)
-        .stderr_is("sed: :0:3: error: incomplete command\n");
+        .stderr_is("sed: :0: incomplete command\n");
 }
 
 #[test]
@@ -1107,7 +1107,7 @@ fn test_addr0_non_posix() {
         .args(&["--posix", "0,/foo/p"])
         .fails()
         .code_is(1)
-        .stderr_is("sed: <script argument 1>:1:2: error: address 0 is invalid in POSIX mode\n");
+        .stderr_is("sed: -e expression #1, char 2: address 0 is invalid in POSIX mode\n");
 }
 
 #[test]
@@ -1116,7 +1116,7 @@ fn test_addr0_second_required() {
         .args(&["0p"])
         .fails()
         .code_is(1)
-        .stderr_is("sed: <script argument 1>:1:2: error: address 0 requires a second address\n");
+        .stderr_is("sed: -e expression #1, char 2: address 0 requires a second address\n");
 }
 
 #[test]
@@ -1125,7 +1125,7 @@ fn test_addr0_second_re_only() {
         .args(&["0,4p"])
         .fails()
         .code_is(1)
-        .stderr_is("sed: <script argument 1>:1:4: error: address 0 can only be used with a regular expression or ~step\n");
+        .stderr_is("sed: -e expression #1, char 4: address 0 can only be used with a regular expression or ~step\n");
 }
 
 #[test]
@@ -1134,7 +1134,7 @@ fn test_step_match_non_posix() {
         .args(&["--posix", "3~2p"])
         .fails()
         .code_is(1)
-        .stderr_is("sed: <script argument 1>:1:3: error: ~step is invalid in POSIX mode\n");
+        .stderr_is("sed: -e expression #1, char 3: ~step is invalid in POSIX mode\n");
 }
 
 #[test]
@@ -1143,7 +1143,7 @@ fn test_step_end_non_posix() {
         .args(&["--posix", "3,~2p"])
         .fails()
         .code_is(1)
-        .stderr_is("sed: <script argument 1>:1:4: error: ~step is invalid in POSIX mode\n");
+        .stderr_is("sed: -e expression #1, char 4: ~step is invalid in POSIX mode\n");
 }
 
 // The following test diverse ways in which regexes are matched.
@@ -1154,7 +1154,7 @@ fn test_fancy_regex_is_match_error() {
         .args(&["-E", r"/(\.+)+\1b$/p", "input/dots-4k.txt"])
         .fails()
         .code_is(2)
-        .stderr_is("sed: <script argument 1>:1:1: 'input/dots-4k.txt':1 error: Error executing regex: Max limit for backtracking count exceeded\n");
+        .stderr_is("sed: -e expression #1, char 1: 'input/dots-4k.txt':1 error: Error executing regex: Max limit for backtracking count exceeded\n");
 }
 
 #[test]
@@ -1163,7 +1163,7 @@ fn test_fancy_regex_find_error() {
         .args(&["-E", r"p;s/(\.+)+\1b$/X/", "input/dots-4k.txt"])
         .fails()
         .code_is(2)
-        .stderr_is("sed: <script argument 1>:1:3: 'input/dots-4k.txt':1 error: Error executing regex: Max limit for backtracking count exceeded\n");
+        .stderr_is("sed: -e expression #1, char 3: 'input/dots-4k.txt':1 error: Error executing regex: Max limit for backtracking count exceeded\n");
 }
 
 #[test]
@@ -1172,7 +1172,7 @@ fn test_fancy_regex_captures_error() {
         .args(&["-E", r"p;s/(\.+)+\1b$/\1/", "input/dots-4k.txt"])
         .fails()
         .code_is(2)
-        .stderr_is("sed: <script argument 1>:1:3: 'input/dots-4k.txt':1 error: Error executing regex: Max limit for backtracking count exceeded\n");
+        .stderr_is("sed: -e expression #1, char 3: 'input/dots-4k.txt':1 error: Error executing regex: Max limit for backtracking count exceeded\n");
 }
 
 #[test]
@@ -1181,7 +1181,7 @@ fn test_fancy_regex_captures_iter_error() {
         .args(&["-E", r"p;s/(\.+)+\1b$/\1/3", "input/dots-4k.txt"])
         .fails()
         .code_is(2)
-        .stderr_is("sed: <script argument 1>:1:3: 'input/dots-4k.txt':1 error: error retrieving RE captures: Error executing regex: Max limit for backtracking count exceeded\n");
+        .stderr_is("sed: -e expression #1, char 3: 'input/dots-4k.txt':1 error: error retrieving RE captures: Error executing regex: Max limit for backtracking count exceeded\n");
 }
 
 #[test]
@@ -1190,7 +1190,7 @@ fn test_write_file_failure() {
         .args(&["w /xyzzy/xyzy", LINES1])
         .fails()
         .code_is(2)
-        .stderr_contains("sed: <script argument 1>:1:1: error: creating file '/xyzzy/xyzy':");
+        .stderr_contains("sed: -e expression #1, char 1: creating file '/xyzzy/xyzy':");
 }
 
 #[test]
@@ -1199,7 +1199,7 @@ fn test_missing_substitute_re() {
         .args(&["l;s//foo/", LINES1])
         .fails()
         .code_is(2)
-        .stderr_is("sed: <script argument 1>:1:3: 'input/lines1':1 error: no previous regular expression\n");
+        .stderr_is("sed: -e expression #1, char 3: 'input/lines1':1 error: no previous regular expression\n");
 }
 
 #[test]
@@ -1208,7 +1208,7 @@ fn test_missing_address_re() {
         .args(&["l\np;//s/foo/bar/", LINES1])
         .fails()
         .code_is(2)
-        .stderr_is("sed: <script argument 1>:2:3: 'input/lines1':1 error: no previous regular expression\n");
+        .stderr_is("sed: -e expression #1, char 3: 'input/lines1':1 error: no previous regular expression\n");
 }
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Fix `l` command default width from 60 to 70 (matching GNU sed)
- Wire `-l` flag and COLS env var to `l` command width
- Reject `l<N>` (GNU extension) in --posix mode
- Accept `}` and `#` as valid command terminators (fixes command-endings)
- Accept `}` and `#` as valid substitute flag terminators
- Eat spaces before command endings (e.g. `y/1/a/ ;d`)
- Scope `#n` silent mode to first script source only (fixes comment-n)
- Drop backslash for unknown escape sequences in s/// replacement (GNU behavior)
- Match GNU sed error message format: `-e expression #N, char C:` for string scripts, `file:line:` for file scripts
- Add `get_source_index()` to ScriptLineProvider
- Add test-results.txt to .gitignore

GNU testsuite results: 7 → 9 passing (command-endings, comment-n now pass).