### PR TITLE
Cargo.toml: bump Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 keywords = ["sed", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94.0"
 
 build = "build.rs"
 


### PR DESCRIPTION
Since this project is WIP and none of (lts) distribution package it, there is no reason to restrict toolchain at here and build time.