### PR TITLE
assert_fs belongs in dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ xattr = "1.3.1"
 
 
 [dependencies]
-assert_fs = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }
@@ -75,6 +74,7 @@ textwrap = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]
+assert_fs = { workspace = true }
 chrono = { workspace = true }
 divan = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
Closes #323 
A simple move to fix the wasm build