### PR TITLE
Fix \?, \+ and \| to be treated as ERE in BRE mode

### DIFF
--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -533,7 +533,7 @@ fn parse_command_ending(
 }
 
 /// Convert a primitive BRE pattern to a safe ERE-compatible pattern string.
-/// - Replaces `\(` and `\)` with `(` and `)`.
+/// - Replaces `\(`, `\)`, `\?`, `\+` and `\|` with `(`, `)`, `?`, `+` and `|`.
 /// - Puts single-digit back-references in non-capturing groups..
 /// - Escapes ERE-only metacharacters: `+ ? { } | ( )`.
 /// - Leaves all other characters as-is.
@@ -553,6 +553,18 @@ fn bre_to_ere(pattern: &str) -> String {
                 Some(')') => {
                     chars.next();
                     result.push(')'); // Group end
+                }
+                Some('?') => {
+                    chars.next();
+                    result.push('?'); // Quantifier 0 or 1
+                }
+                Some('+') => {
+                    chars.next();
+                    result.push('+'); // Quantifier 1 or more
+                }
+                Some('|') => {
+                    chars.next();
+                    result.push('|'); // Alternation operator
                 }
                 Some(v) if v.is_ascii_digit() => {
                     // Back-reference.  In sed BREs these are single-digit
@@ -2192,7 +2204,7 @@ mod tests {
     // bre_to_ere
     #[test]
     fn test_bre_group_translation() {
-        assert_eq!(bre_to_ere(r"\(abc\)"), "(abc)");
+        assert_eq!(bre_to_ere(r"\(a\?b\+c\|\)"), "(a?b+c|)");
         assert_eq!(bre_to_ere(r"a\(b\)c"), "a(b)c");
     }
 

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -300,6 +300,15 @@ check_output!(
         LINES1
     ]
 );
+check_output!(
+    subst_quantifier_zero_or_one,
+    ["-e", r"s/_[0-9]\([0-9]\)\?/_x\1/g", LINES1]
+);
+check_output!(
+    subst_quantifier_one_or_more,
+    ["-e", r"s/_[0-9]\+/_x/g", LINES1]
+);
+check_output!(subst_alternation_operator, ["-e", r"s/0\|1/x/g", LINES1]);
 check_output!(subst_multiline, ["-e", "s/_/u0\\\nu1\\\nu2/g", LINES1]);
 check_output!(subst_numbered_replacement, ["-e", r"s/./X/4", LINES1]);
 check_output!(subst_brace, ["-e", r"s/[123]/X/g", LINES1]);

--- a/tests/fixtures/sed/output/subst_alternation_operator
+++ b/tests/fixtures/sed/output/subst_alternation_operator
@@ -1,0 +1,14 @@
+lx_x
+lx_2
+lx_3
+lx_4
+lx_5
+lx_6
+lx_7
+lx_8
+lx_9
+lx_xx
+lx_xx
+lx_x2
+lx_x3
+lx_x4

--- a/tests/fixtures/sed/output/subst_quantifier_one_or_more
+++ b/tests/fixtures/sed/output/subst_quantifier_one_or_more
@@ -1,0 +1,14 @@
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x

--- a/tests/fixtures/sed/output/subst_quantifier_zero_or_one
+++ b/tests/fixtures/sed/output/subst_quantifier_zero_or_one
@@ -1,0 +1,14 @@
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x
+l1_x0
+l1_x1
+l1_x2
+l1_x3
+l1_x4


### PR DESCRIPTION
Fixes https://github.com/uutils/sed/issues/288.

It also passes a test from the GNU testsuite comparison.

The brace quantifiers { and } are not included because they are already solved in PR https://github.com/uutils/sed/pull/328.