### PR TITLE
Bump `ctor` & adapt to change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f"
+checksum = "3429e8f8e3ce0ffe475c411850f70468c70d7a87d2ac3d15dd44703fb885aede"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -858,9 +858,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "link-section"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40"
+checksum = "ea2c24837c4fd5ab6a31d64133eae954f5199247523cf29586117e85245c0dd3"
 
 [[package]]
 name = "linktime-proc-macro"
@@ -1240,7 +1240,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "codspeed-divan-compat",
- "ctor 0.12.0",
+ "ctor 0.13.1",
  "fancy-regex",
  "hex",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ regex = "1.10.4"
 sha2 = "0.11"
 sysinfo = "0.38"
 tempfile = "3.10.1"
-textwrap = { version = "0.16.1", features = ["terminal_size"] }
 terminal_size = "0.4.2"
+textwrap = { version = "0.16.1", features = ["terminal_size"] }
 uucore = { version = "0.8.0", features = ["libc"] }
 xattr = "1.3.1"
 
@@ -60,7 +60,7 @@ xattr = "1.3.1"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }
-ctor = "0.12.0"
+ctor = "0.13.0"
 fancy-regex =  { workspace = true }
 memchr = { workspace = true }
 memmap2.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ xattr = "1.3.1"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }
-ctor = "0.13.0"
 fancy-regex =  { workspace = true }
 memchr = { workspace = true }
 memmap2.workspace = true
@@ -76,6 +75,7 @@ uucore = { workspace = true }
 [dev-dependencies]
 assert_fs = { workspace = true }
 chrono = { workspace = true }
+ctor = "0.13.0"
 divan = { workspace = true }
 hex = { workspace = true }
 libc = { workspace = true }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,7 +7,7 @@ use std::env;
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_sed");
 
 // Use the ctor attribute to run this function before any tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
     unsafe {
         // Necessary for uutests to be able to find the binary


### PR DESCRIPTION
This PR bumps `ctor` from `0.12.0` to `0.13.0` and adapts `tests/tests.rs` to a change in `ctor`. The PR also moves `ctor` to the `dev-dependencies`.