### PR TITLE
fix: allow commands before closing brace

### DIFF
--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -520,6 +520,10 @@ fn parse_command_ending(
         return Ok(());
     }
 
+    if !line.eol() && line.current() == '}' {
+        return Ok(());
+    }
+
     if !line.eol() {
         return compilation_error(
             lines,

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -274,6 +274,17 @@ check_output!(addr_range_odd, ["-n", "1~2p", LINES1]);
 check_output!(addr_range_step_zero, ["-n", "10~0p", LINES1]);
 check_output!(addr_range_end_multiple, ["-n", "/l1_2/,~10p", LINES1]);
 
+#[test]
+fn command_may_end_before_closing_brace() {
+    for script in ["{p}", "1{p}", "/a/{p}"] {
+        new_ucmd!()
+            .arg(script)
+            .pipe_in("a\n")
+            .succeeds()
+            .stdout_is("a\na\n");
+    }
+}
+
 ////////////////////////////////////////////////////////////
 // Substitution: s
 check_output!(subst_any, ["-e", r"s/./X/g", LINES1]);


### PR DESCRIPTION
## Summary
- accept `}` as a command terminator without consuming it, so the group-close handler can still process the brace
- add a regression test for `{p}`, `1{p}`, and `/a/{p}` scripts

Fixes #392.

## Tests
- `cargo fmt --check`
- `cargo test command_may_end_before_closing_brace`
- `cargo test test_sed`
- `cargo test`
- `cargo run --quiet -- '{p}' <<<'a'`
