### PR TITLE
feat: add z command

### DIFF
--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -1327,6 +1327,10 @@ fn get_cmd_spec(
             n_addr: 2,
             handler: compile_empty_command,
         }),
+        'z' if !posix => Ok(CommandSpec {
+            n_addr: 2,
+            handler: compile_empty_command,
+        }),
         'l' => Ok(CommandSpec {
             n_addr: 2,
             handler: compile_number_command,

--- a/src/sed/processor.rs
+++ b/src/sed/processor.rs
@@ -621,6 +621,12 @@ fn process_file(
                     let trans = extract_variant!(command, Transliteration);
                     transliterate(&mut pattern, trans)?;
                 }
+                'z' => {
+                    // Clear the pattern contents, but preserve newline state
+                    // so automatic printing still emits an empty record.
+                    let (pat_content, _) = pattern.fields_mut()?;
+                    pat_content.clear();
+                }
                 ':' => {
                     // Branch target; do nothing.
                 }

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -390,7 +390,6 @@ fn pattern_clear_with_z_preserves_substitution_flag() {
 fn pattern_clear_with_z_is_non_posix() {
     new_ucmd!()
         .args(&["--posix", "z"])
-        .pipe_in("a\n")
         .fails()
         .code_is(1)
         .stderr_is("sed: <script argument 1>:1:1: error: invalid command code `z'\n");

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -358,6 +358,43 @@ check_output!(
     ["-e", r"y10\123456789198765432\101", LINES1]
 );
 check_output!(trans_no_new_line, ["-e", r"y/l/L/", NO_NEW_LINE]);
+
+#[test]
+fn pattern_clear_with_z_command() {
+    new_ucmd!()
+        .arg("z")
+        .pipe_in("a\nb\n")
+        .succeeds()
+        .stdout_is("\n\n");
+}
+
+#[test]
+fn pattern_clear_with_z_command_silent_print() {
+    new_ucmd!()
+        .args(&["-n", "z;p"])
+        .pipe_in("a\nb\n")
+        .succeeds()
+        .stdout_is("\n\n");
+}
+
+#[test]
+fn pattern_clear_with_z_preserves_substitution_flag() {
+    new_ucmd!()
+        .args(&["-n", "s/a/b/;z;t changed;b;:changed;c\\\nchanged"])
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("changed\n");
+}
+
+#[test]
+fn pattern_clear_with_z_is_non_posix() {
+    new_ucmd!()
+        .args(&["--posix", "z"])
+        .pipe_in("a\n")
+        .fails()
+        .code_is(1)
+        .stderr_is("sed: <script argument 1>:1:1: error: invalid command code `z'\n");
+}
 check_output!(trans_newline, ["-e", r"1N;2y/\n/X/", LINES1]);
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- add GNU sed's `z` command outside POSIX mode
- clear the pattern-space contents while preserving newline state for automatic printing
- cover default output, `-n` + explicit print, POSIX rejection, and substitution-flag behavior

Fixes #396.

## Tests
- `cargo fmt --check`
- `cargo test pattern_clear_with_z`
- `cargo test test_sed`
- `cargo test`
- `cargo run --quiet -- 'z' <<'RUNEOF'`
  `a`
  `b`
  `RUNEOF`
