### PR TITLE
feat: add W command

### DIFF
--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -1348,7 +1348,7 @@ fn get_cmd_spec(
             n_addr: 2,
             handler: compile_subst_command,
         }),
-        'w' => Ok(CommandSpec {
+        'w' | 'W' if !posix => Ok(CommandSpec {
             n_addr: 2,
             handler: compile_write_file_command,
         }),

--- a/src/sed/processor.rs
+++ b/src/sed/processor.rs
@@ -607,6 +607,15 @@ fn process_file(
                     let writer = extract_variant!(command, NamedWriter);
                     writer.borrow_mut().write_line(pattern.as_str()?)?;
                 }
+                'W' => {
+                    // Append only the first line of the pattern space.
+                    let writer = extract_variant!(command, NamedWriter);
+                    let pattern_text = pattern.as_str()?;
+                    let line = pattern_text
+                        .split_once('\n')
+                        .map_or(pattern_text, |(first_line, _)| first_line);
+                    writer.borrow_mut().write_line(line)?;
+                }
                 'x' => {
                     // Exchange the contents of the pattern and hold spaces.
                     let (pat_content, pat_has_newline) = pattern.fields_mut()?;

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -818,6 +818,32 @@ fn write_two_files() -> std::io::Result<()> {
     Ok(())
 }
 
+#[test]
+fn write_first_line_with_w_command() -> std::io::Result<()> {
+    let temp = NamedTempFile::new()?;
+    let cmd = format!("N;W {}", temp.path().display());
+
+    new_ucmd!()
+        .args(&["-n", "-e", &cmd])
+        .pipe_in("abc\ndef\n")
+        .succeeds();
+
+    let mut actual = String::new();
+    temp.reopen()?.read_to_string(&mut actual)?;
+    assert_eq!(actual, "abc\n");
+
+    Ok(())
+}
+
+#[test]
+fn write_first_line_with_w_command_is_non_posix() {
+    new_ucmd!()
+        .args(&["--posix", "W /tmp/out"])
+        .fails()
+        .code_is(1)
+        .stderr_is("sed: <script argument 1>:1:1: error: invalid command code `W'\n");
+}
+
 ////////////////////////////////////////////////////////////
 // =, l commands
 check_output!(number_continuous, ["/l2_/=", LINES1, LINES2]);


### PR DESCRIPTION
## Summary
- add GNU sed's `W` command outside POSIX mode
- reuse the existing `w` filename parser/writer and write only the first pattern-space line
- cover `N;W file` behavior and POSIX rejection

Fixes #398.

## Tests
- `cargo fmt --check`
- `cargo test write_first_line_with_w_command`
- `cargo test test_sed`
- `cargo test`
- `printf 'abc\ndef\n' | cargo run --quiet -- -n 'N;W/dev/stdout'`
