### PR TITLE
fix: preserve latest binary executable mode

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -56,7 +56,7 @@ jobs:
         ## Build Rust sed binary
         cd 'sed'
         cargo build --config=profile.release.strip=true --profile=release #-fast
-        zstd -19 target/release/sed -o ../sed-x86_64-unknown-linux-gnu.zst
+        tar -C target/release -cf - sed | zstd -19 -o ../sed-x86_64-unknown-linux-gnu.tar.zst
     - name: Publish latest commit
       uses: softprops/action-gh-release@v3
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -67,7 +67,7 @@ jobs:
         draft: false
         prerelease: true
         files: |
-          sed-x86_64-unknown-linux-gnu.zst
+          sed-x86_64-unknown-linux-gnu.tar.zst
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Further work aims to:
 
 ## Installation
 
-We provide binary for Linux x86_64 from main branch at https://github.com/uutils/sed/releases/tag/latest-commit .
+We provide a Linux x86_64 binary archive from the main branch at
+https://github.com/uutils/sed/releases/tag/latest-commit .
 
 For other platforms, ensure you have Rust installed on your system. You can install Rust through [rustup](https://rustup.rs/).
 


### PR DESCRIPTION
## Summary
- package the latest-commit Linux binary as a `tar.zst` archive instead of a raw zstd-compressed file
- preserve the executable permission bit when users extract the archive
- update the README wording to describe the latest-commit download as an archive

Fixes #277.

## Tests
- local archive check: `tar -C <dir> -cf - sed | zstd -19 -o sed-x86_64-unknown-linux-gnu.tar.zst`, then `zstd -dc ... | tar -xf -` and `test -x sed`
- `git diff --check`
- `cargo test test_version`
- `cargo test`
