### PR TITLE
fix: identify uutils in cli output

### DIFF
--- a/src/sed/mod.rs
+++ b/src/sed/mod.rs
@@ -24,14 +24,15 @@ use crate::sed::command::{ProcessingContext, StringSpace};
 use crate::sed::compiler::compile;
 use crate::sed::processor::process_all_files;
 use crate::sed::script_line_provider::ScriptValue;
-use clap::{Arg, ArgMatches, Command, arg, crate_version};
+use clap::{Arg, ArgMatches, Command, arg};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use uucore::error::{UResult, UUsageError};
 use uucore::format_usage;
 
-const ABOUT: &str = "Stream editor for filtering and transforming text";
+const ABOUT: &str = "Stream editor for filtering and transforming text (part of uutils)";
 const USAGE: &str = "sed [OPTION]... [script] [file]...";
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (uutils)");
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -52,7 +53,7 @@ pub fn uu_app() -> Command {
     let util_name = uucore::util_name();
 
     Command::new(util_name)
-        .version(crate_version!())
+        .version(VERSION)
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .args_override_self(true)

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -38,7 +38,18 @@ fn test_version() {
         .arg("--version")
         .succeeds()
         .no_stderr()
-        .stdout_is(short);
+        .stdout_is(&short);
+
+    assert!(short.contains("uutils"));
+}
+
+#[test]
+fn test_help_mentions_uutils() {
+    new_ucmd!()
+        .arg("--help")
+        .succeeds()
+        .no_stderr()
+        .stdout_contains("part of uutils");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- include `(uutils)` in `sed --version` / `sed -V`
- mention that sed is part of uutils in the help description
- add regression coverage for both CLI outputs

Fixes #407.

## Tests
- `cargo run --quiet -- --version`
- `cargo run --quiet -- --help`
- `cargo test uutils`
- `cargo test test_version`
- `cargo fmt --check`
- `git diff --check`
- `cargo test test_sed`
- `cargo test`
