### PR TITLE
fix: reject empty text commands

### DIFF
--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -1151,6 +1151,14 @@ fn compile_text_command_gnu(
     // True after a \ at the end of a line
     let mut escaped_newline = false;
 
+    if line.eol() {
+        return compilation_error(
+            lines,
+            line,
+            format!("command `{}' expects \\ followed by text", cmd.code),
+        );
+    }
+
     // Skip optional \.
     if !line.eol() && line.current() == '\\' {
         line.advance();
@@ -2797,19 +2805,16 @@ mod tests {
     }
 
     #[test]
-    fn test_compile_text_command_gnu_optional_backslash_eol_eof() {
+    fn test_compile_text_command_gnu_no_text() {
         let mut chars = make_char_provider("a");
         let mut lines = make_line_provider(&[]);
         let mut cmd = Command::default();
         let mut context = ProcessingContext::default();
 
-        compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
-        match &cmd.data {
-            CommandData::Text(text) => {
-                assert_eq!(text.to_string(), "\n");
-            }
-            _ => panic!("Expected CommandData::Text"),
-        }
+        let result = compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("expects \\ followed by text"));
     }
 
     #[test]

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -1115,6 +1115,17 @@ fn test_incomplete_test_command_posix() {
 }
 
 #[test]
+fn test_empty_text_commands_fail() {
+    for command in ["a", "c", "i"] {
+        new_ucmd!()
+            .args(&["-e", command])
+            .fails()
+            .code_is(1)
+            .stderr_contains(format!("command `{command}' expects \\ followed by text"));
+    }
+}
+
+#[test]
 fn test_addr0_non_posix() {
     new_ucmd!()
         .args(&["--posix", "0,/foo/p"])


### PR DESCRIPTION
## Summary
- reject bare GNU-mode `a`, `c`, and `i` commands that provide no text
- keep same-line GNU text extensions such as `a hello` working
- add integration and compiler regression coverage for the empty-text case

Fixes #307.

## Tests
- manual `a` / `c` / `i` empty-command reproduction
- manual `a hello` / `c hello` / `i hello` compatibility check
- `cargo test test_empty_text_commands_fail`
- `cargo test compile_text_command_gnu`
- `cargo fmt --check`
- `git diff --check`
- `cargo test test_sed`
- `cargo test`
