### PR TITLE
regex: accept literal [ in bracket expressions

### DIFF
--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -628,6 +628,73 @@ fn bre_to_ere(pattern: &str) -> String {
     result
 }
 
+fn escape_literal_open_brackets_in_classes(pattern: &str) -> String {
+    let mut result = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => {
+                result.push('\\');
+                if let Some(escaped) = chars.next() {
+                    result.push(escaped);
+                }
+                continue;
+            }
+            '[' => result.push('['),
+            _ => {
+                result.push(c);
+                continue;
+            }
+        }
+
+        if chars.peek() == Some(&'^') {
+            result.push('^');
+            chars.next();
+        }
+
+        if chars.peek() == Some(&']') {
+            result.push(']');
+            chars.next();
+        }
+
+        while let Some(class_char) = chars.next() {
+            match class_char {
+                ']' => {
+                    result.push(']');
+                    break;
+                }
+                '\\' => {
+                    result.push('\\');
+                    if let Some(escaped) = chars.next() {
+                        result.push(escaped);
+                    }
+                }
+                '[' => match chars.peek() {
+                    Some(':') | Some('.') | Some('=') => {
+                        result.push('[');
+                        let marker = chars.next().unwrap();
+                        result.push(marker);
+
+                        while let Some(posix_char) = chars.next() {
+                            result.push(posix_char);
+                            if posix_char == marker && chars.peek() == Some(&']') {
+                                result.push(']');
+                                chars.next();
+                                break;
+                            }
+                        }
+                    }
+                    _ => result.push_str(r"\["),
+                },
+                _ => result.push(class_char),
+            }
+        }
+    }
+
+    result
+}
+
 /// Compile the provided regular expression string into a corresponding engine.
 /// An empty pattern results in None, which means that the last RE employed
 /// at runtime will be used.
@@ -644,15 +711,17 @@ fn compile_regex(
 
     // Convert basic to extended regular expression if needed.
     let pattern = if context.regex_extended {
-        pattern
+        pattern.to_string()
     } else {
-        &bre_to_ere(pattern)
+        bre_to_ere(pattern)
     };
+    let pattern = escape_literal_open_brackets_in_classes(&pattern);
+
     // Add case-insensitive modifier if needed.
     let pattern = if icase {
         format!("(?i){pattern}")
     } else {
-        pattern.to_string()
+        pattern
     };
 
     // Compile into engine.
@@ -1619,6 +1688,65 @@ mod tests {
         let (lines, chars) = dummy_providers();
         let result = compile_regex(&lines, &chars, "a[d", &ctx(), false);
         assert!(result.is_err()); // Should fail due to open bracketed expression
+    }
+
+    #[test]
+    fn test_compile_re_literal_open_bracket_in_classes() {
+        let (lines, chars) = dummy_providers();
+        let mut context = ctx();
+        context.regex_extended = true;
+
+        for (pattern, matching, non_matching) in [
+            ("[[]", "[", "x"),
+            ("[^[]", "x", "["),
+            ("[a[b]", "[", "x"),
+            ("[^a[b]", "x", "["),
+        ] {
+            let regex = compile_regex(&lines, &chars, pattern, &context, false)
+                .unwrap()
+                .expect("regex should be present");
+            assert!(
+                regex
+                    .is_match(&mut IOChunk::new_from_str(matching))
+                    .unwrap(),
+                "{pattern:?} should match {matching:?}"
+            );
+            assert!(
+                !regex
+                    .is_match(&mut IOChunk::new_from_str(non_matching))
+                    .unwrap(),
+                "{pattern:?} should not match {non_matching:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compile_re_escaped_open_bracket_before_class() {
+        let (lines, chars) = dummy_providers();
+        let mut context = ctx();
+        context.regex_extended = true;
+
+        let regex = compile_regex(&lines, &chars, r"\[[a]", &context, false)
+            .unwrap()
+            .expect("regex should be present");
+        assert!(regex.is_match(&mut IOChunk::new_from_str("[a")).unwrap());
+        assert!(!regex.is_match(&mut IOChunk::new_from_str("[b")).unwrap());
+    }
+
+    #[test]
+    fn test_escape_literal_open_brackets_preserves_class_syntax() {
+        for (pattern, expected) in [
+            (r"[a\]b]", r"[a\]b]"),
+            (r"[[:alpha:][x]", r"[[:alpha:]\[x]"),
+            (r"[[=a=][x]", r"[[=a=]\[x]"),
+            (r"[[.ch.][x]", r"[[.ch.]\[x]"),
+        ] {
+            assert_eq!(
+                escape_literal_open_brackets_in_classes(pattern),
+                expected,
+                "{pattern:?}"
+            );
+        }
     }
 
     // compile_address

--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -628,6 +628,14 @@ fn bre_to_ere(pattern: &str) -> String {
     result
 }
 
+/// Escape literal `[` characters that appear inside a bracket expression.
+///
+/// Within a bracket expression a `[` only begins a sub-construct when followed
+/// by `:`, `.`, or `=` (e.g. `[:alpha:]`); elsewhere it is an ordinary
+/// character. The `regex` crate rejects such a bare `[`, so we escape those
+/// occurrences (`[` becomes `\[`) before handing the pattern to the engine. See
+/// POSIX 9.3.5 RE Bracket Expression:
+/// <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_03_05>
 fn escape_literal_open_brackets_in_classes(pattern: &str) -> String {
     let mut result = String::with_capacity(pattern.len());
     let mut chars = pattern.chars().peekable();

--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -655,6 +655,74 @@ fn bre_to_ere(pattern: &[u8]) -> Vec<u8> {
     result
 }
 
+fn escape_literal_open_brackets_in_classes(pattern: &[u8]) -> Vec<u8> {
+    let mut result = Vec::with_capacity(pattern.len());
+    let mut bytes = pattern.iter().copied().peekable();
+
+    while let Some(c) = bytes.next() {
+        match c {
+            b'\\' => {
+                result.push(b'\\');
+                if let Some(escaped) = bytes.next() {
+                    result.push(escaped);
+                }
+                continue;
+            }
+            b'[' => result.push(b'['),
+            _ => {
+                result.push(c);
+                continue;
+            }
+        }
+
+        if bytes.peek() == Some(&b'^') {
+            result.push(b'^');
+            bytes.next();
+        }
+
+        if bytes.peek() == Some(&b']') {
+            result.push(b']');
+            bytes.next();
+        }
+
+        while let Some(class_byte) = bytes.next() {
+            match class_byte {
+                b']' => {
+                    result.push(b']');
+                    break;
+                }
+                b'\\' => {
+                    result.push(b'\\');
+                    if let Some(escaped) = bytes.next() {
+                        result.push(escaped);
+                    }
+                }
+                b'[' => {
+                    if let Some(&marker @ (b':' | b'.' | b'=')) = bytes.peek() {
+                        bytes.next();
+                        result.push(b'[');
+                        result.push(marker);
+
+                        while let Some(posix_byte) = bytes.next() {
+                            result.push(posix_byte);
+                            if posix_byte == marker && bytes.peek() == Some(&b']') {
+                                result.push(b']');
+                                bytes.next();
+                                break;
+                            }
+                        }
+                    } else {
+                        result.extend_from_slice(br"\[");
+                    }
+                }
+                _ => result.push(class_byte),
+            }
+        }
+    }
+
+    result
+}
+
 /// Compile the provided regular expression string into a corresponding engine.
 /// An empty pattern results in None, which means that the last RE employed
 /// at runtime will be used.
@@ -677,6 +745,7 @@ fn compile_regex(
     } else {
         bre_to_ere(pattern)
     };
+    let pattern = escape_literal_open_brackets_in_classes(&pattern);
 
     // Add any required modifiers.
     let mut modifiers = Vec::new();
@@ -1950,6 +2019,65 @@ mod tests {
                 .is_match(&mut IOChunk::new_from_str("foo\nbar"))
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn test_compile_re_literal_open_bracket_in_classes() {
+        let (lines, chars) = dummy_providers();
+        let mut context = ctx();
+        context.regex_extended = true;
+
+        for (pattern, matching, non_matching) in [
+            ("[[]", "[", "x"),
+            ("[^[]", "x", "["),
+            ("[a[b]", "[", "x"),
+            ("[^a[b]", "x", "["),
+        ] {
+            let regex = compile_regex(&lines, &chars, pattern, &context, false, false)
+                .unwrap()
+                .expect("regex should be present");
+            assert!(
+                regex
+                    .is_match(&mut IOChunk::new_from_str(matching))
+                    .unwrap(),
+                "{pattern:?} should match {matching:?}"
+            );
+            assert!(
+                !regex
+                    .is_match(&mut IOChunk::new_from_str(non_matching))
+                    .unwrap(),
+                "{pattern:?} should not match {non_matching:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compile_re_escaped_open_bracket_before_class() {
+        let (lines, chars) = dummy_providers();
+        let mut context = ctx();
+        context.regex_extended = true;
+
+        let regex = compile_regex(&lines, &chars, r"\[[a]", &context, false, false)
+            .unwrap()
+            .expect("regex should be present");
+        assert!(regex.is_match(&mut IOChunk::new_from_str("[a")).unwrap());
+        assert!(!regex.is_match(&mut IOChunk::new_from_str("[b")).unwrap());
+    }
+
+    #[test]
+    fn test_escape_literal_open_brackets_preserves_class_syntax() {
+        for (pattern, expected) in [
+            (r"[a\]b]", r"[a\]b]"),
+            (r"[[:alpha:][x]", r"[[:alpha:]\[x]"),
+            (r"[[=a=][x]", r"[[=a=]\[x]"),
+            (r"[[.ch.][x]", r"[[.ch.]\[x]"),
+        ] {
+            assert_eq!(
+                escape_literal_open_brackets_in_classes(pattern.as_bytes()),
+                expected.as_bytes(),
+                "{pattern:?}"
+            );
+        }
     }
 
     // compile_address

--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -655,6 +655,14 @@ fn bre_to_ere(pattern: &[u8]) -> Vec<u8> {
     result
 }
 
+/// Escape literal `[` characters that appear inside a bracket expression.
+///
+/// Within a bracket expression a `[` only begins a sub-construct when followed
+/// by `:`, `.`, or `=` (e.g. `[:alpha:]`); elsewhere it is an ordinary
+/// character. The `regex` crate rejects such a bare `[`, so we escape those
+/// occurrences (`[` becomes `\[`) before handing the pattern to the engine. See
+/// POSIX 9.3.5 RE Bracket Expression:
+/// <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_03_05>
 fn escape_literal_open_brackets_in_classes(pattern: &[u8]) -> Vec<u8> {
     let mut result = Vec::with_capacity(pattern.len());
     let mut bytes = pattern.iter().copied().peekable();

--- a/src/sed/delimited_parser.rs
+++ b/src/sed/delimited_parser.rs
@@ -263,10 +263,9 @@ fn parse_character_class(
 
                 continue;
             }
-            // Not a POSIX construct — treat as literal
+            // Not a POSIX construct: '[' is literal, and the next character
+            // may still terminate or otherwise participate in the class.
             result.push('[');
-            result.push(marker);
-            line.advance();
             continue;
         }
 
@@ -844,6 +843,38 @@ mod tests {
         let lines = test_lines();
         let result = parse_character_class(&lines, &mut line).unwrap();
         assert_eq!(result, "[^]abc]");
+    }
+
+    #[test]
+    fn test_literal_open_bracket() {
+        let mut line = char_provider_from("[[]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line).unwrap();
+        assert_eq!(result, "[[]");
+    }
+
+    #[test]
+    fn test_negated_literal_open_bracket() {
+        let mut line = char_provider_from("[^[]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line).unwrap();
+        assert_eq!(result, "[^[]");
+    }
+
+    #[test]
+    fn test_literal_open_bracket_in_class() {
+        let mut line = char_provider_from("[a[b]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line).unwrap();
+        assert_eq!(result, "[a[b]");
+    }
+
+    #[test]
+    fn test_negated_literal_open_bracket_in_class() {
+        let mut line = char_provider_from("[^a[b]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line).unwrap();
+        assert_eq!(result, "[^a[b]");
     }
 
     #[test]

--- a/src/sed/delimited_parser.rs
+++ b/src/sed/delimited_parser.rs
@@ -304,10 +304,9 @@ fn parse_character_class(
 
                 continue;
             }
-            // Not a POSIX construct — treat as literal
+            // Not a POSIX construct: '[' is literal, and the next character
+            // may still terminate or otherwise participate in the class.
             result.push(b'[');
-            result.push(line.current_byte());
-            line.advance();
             continue;
         }
 
@@ -963,6 +962,38 @@ mod tests {
         let lines = test_lines();
         let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
         assert_eq!(result, b"[^]abc]");
+    }
+
+    #[test]
+    fn test_literal_open_bracket() {
+        let mut line = char_provider_from("[[]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[[]");
+    }
+
+    #[test]
+    fn test_negated_literal_open_bracket() {
+        let mut line = char_provider_from("[^[]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[^[]");
+    }
+
+    #[test]
+    fn test_literal_open_bracket_in_class() {
+        let mut line = char_provider_from("[a[b]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[a[b]");
+    }
+
+    #[test]
+    fn test_negated_literal_open_bracket_in_class() {
+        let mut line = char_provider_from("[^a[b]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[^a[b]");
     }
 
     #[test]

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -517,6 +517,23 @@ check_output!(subst_re_reuse, ["-e", r"2s//M/;1s/l/L/", LINES1]);
 check_output!(subst_newline_class, ["-n", r"1{;N;s/[\n]/X/;p;}", LINES1]);
 check_output!(subst_newline_re, ["-n", r"1{;N;s/\n/X/;p;}", LINES1]);
 
+#[test]
+fn test_subst_literal_open_bracket_in_character_classes() {
+    for (script, input, expected) in [
+        (r"s/[[]/X/", "x\n", "x\n"),
+        (r"s/[^[]/X/", "x\n", "X\n"),
+        (r"s/[a[b]/X/", "x\n", "x\n"),
+        (r"s/[^a[b]/X/", "x\n", "X\n"),
+        (r"s/\[[a]/X/", "[a\n", "X\n"),
+    ] {
+        new_ucmd!()
+            .args(&["-E", script])
+            .pipe_in(input)
+            .succeeds()
+            .stdout_is(expected);
+    }
+}
+
 // Check appropriate selection and behavior of fast_Regex matcher
 // Literal matcher
 check_output!(subst_literal_start, ["-e", r"s/^l1/L1/", LINES1]);

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -568,6 +568,23 @@ fn subst_multiline_flag_matches_embedded_line_end() {
         .stdout_is("foX\nbaX\n");
 }
 
+#[test]
+fn test_subst_literal_open_bracket_in_character_classes() {
+    for (script, input, expected) in [
+        (r"s/[[]/X/", "x\n", "x\n"),
+        (r"s/[^[]/X/", "x\n", "X\n"),
+        (r"s/[a[b]/X/", "x\n", "x\n"),
+        (r"s/[^a[b]/X/", "x\n", "X\n"),
+        (r"s/\[[a]/X/", "[a\n", "X\n"),
+    ] {
+        new_ucmd!()
+            .args(&["-E", script])
+            .pipe_in(input)
+            .succeeds()
+            .stdout_is(expected);
+    }
+}
+
 // Check appropriate selection and behavior of fast_Regex matcher
 // Literal matcher
 check_output!(subst_literal_start, ["-e", r"s/^l1/L1/", LINES1]);


### PR DESCRIPTION
POSIX allows '[' to represent itself inside a bracket expression unless it starts a character class, collating symbol, or equivalence class construct. The parser was consuming the following character after a literal '[', which made '[[]' look unterminated, and the Rust regex backend also rejects unescaped literal '[' in classes.

Reproduce the compatibility gap by comparing these commands:

    printf 'x\n' | ./target/debug/sed -E 's/[[]/X/'

    printf 'x\n' | gsed -E 's/[[]/X/'

    printf 'x\n' | ./target/debug/sed -E 's/[^[]/X/'

    printf 'x\n' | gsed -E 's/[^[]/X/'

Before this change, uutils sed rejected the scripts as unterminated or invalid regexes while GNU sed parsed them cleanly. After this change the outputs match GNU sed: x, X, x, and X for the reported cases.

Leave the following character available for normal class parsing, then escape literal '[' characters inside parsed classes before compiling with the regex backend. Add parser, compiler, and command-level regressions for the failing sed -E substitution cases.

Observed this while trying to install Python 3.14.5 with Pyenv and uutils `sed` on the PATH, which failed.