### PR TITLE
Implement `e` (execute) command

### DIFF
--- a/src/sed/command.rs
+++ b/src/sed/command.rs
@@ -223,6 +223,7 @@ pub struct Substitution {
     pub replacement: ReplacementTemplate,             // Specified broken-down replacement
     pub occurrence: usize,                            // Which occurrence to substitute
     pub print_flag: bool,                             // True if 'p' flag
+    pub p_before_e: bool,                             // True if 'p' appears before 'e'
     pub ignore_case: bool,                            // True if 'I' flag
     pub execute: bool,                                // True if 'e' flag (GNU extension)
     pub multiline: bool,                              // True if 'm' or 'M' flag (GNU extension)

--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -1293,6 +1293,104 @@ fn compile_text_command_posix(
     Ok(CommandHandling::Continue)
 }
 
+// Handles e
+// With no argument, the command executes the pattern space as a shell
+// command at runtime. With an argument, the rest of the line is the
+// command to run, following the same escape and backslash-newline
+// continuation rules as the GNU a/c/i text argument.
+fn compile_execute_command(
+    lines: &mut ScriptLineProvider,
+    line: &mut ScriptCharProvider,
+    cmd: &mut Command,
+    context: &mut ProcessingContext,
+) -> UResult<CommandHandling> {
+    if context.posix || context.sandbox {
+        return compilation_error(
+            lines,
+            line,
+            "the 'e' command is not allowed with --posix or --sandbox",
+        );
+    }
+
+    line.advance(); // Skip the command character.
+    line.eat_spaces(); // Skip any leading whitespace.
+
+    if line.eol() {
+        // No argument: execute the pattern space itself at runtime.
+        cmd.data = CommandData::None;
+        return Ok(CommandHandling::Continue);
+    }
+
+    // True after a \ at the end of a line
+    let mut escaped_newline = false;
+
+    // Skip optional \
+    if line.current() == '\\' {
+        line.advance();
+        escaped_newline = line.eol();
+    }
+
+    // Gather the command text. Stop on a non-escaped newline. Unlike most
+    // other commands, ';' does not terminate the argument. The rest of the
+    // (possibly continued) line is consumed unconditionally.
+    let mut text = String::new();
+    // True once a continuation line has actually been pulled in. A dangling
+    // leading backslash with no line to continue into is treated as no
+    // argument at all, matching GNU sed. However once a continuation succeeds,
+    // even into an empty line, we're committed to producing a (possibly empty)
+    // Text argument from then on.
+    let mut continued = false;
+    'text_content: loop {
+        if escaped_newline {
+            match lines.next_line()? {
+                None => {
+                    break 'text_content;
+                }
+                Some(line_string) => {
+                    *line = ScriptCharProvider::new(&line_string);
+                    continued = true;
+                }
+            }
+            escaped_newline = false;
+        }
+
+        // Non-escaped newline
+        if line.eol() {
+            break 'text_content;
+        }
+
+        if line.current() == '\\' {
+            line.advance();
+
+            if line.eol() {
+                escaped_newline = true;
+                text.push('\n');
+                continue 'text_content;
+            }
+
+            if let Some(decoded) = parse_char_escape(line) {
+                text.push(decoded);
+            } else {
+                // Invalid escapes result in the escaped character.
+                text.push(line.current());
+                line.advance();
+            }
+        } else {
+            text.push(line.current());
+            line.advance();
+        }
+    }
+
+    cmd.data = if text.is_empty() && !continued {
+        // A dangling leading backslash with nothing left to continue into.
+        // Treat this the same as no argument at all.
+        CommandData::None
+    } else {
+        CommandData::Text(Rc::from(text))
+    };
+    Ok(CommandHandling::Continue)
+}
+
 // Return the specification for the command letter at the current line position
 // checking for diverse errors.
 fn get_verified_cmd_spec(
@@ -1378,6 +1476,11 @@ fn get_cmd_spec(
         'Q' => Ok(CommandSpec {
             n_addr: 1,
             handler: compile_number_command,
+        }),
+        // e is a GNU extension
+        'e' => Ok(CommandSpec {
+            n_addr: 2,
+            handler: compile_execute_command,
         }),
         'r' => Ok(CommandSpec {
             n_addr: if posix { 1 } else { 2 },

--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -940,6 +940,7 @@ pub fn compile_subst_flags(
 
     subst.occurrence = 1; // default
     subst.print_flag = false;
+    subst.p_before_e = false;
     subst.ignore_case = false;
     subst.execute = false;
     subst.multiline = false;
@@ -967,6 +968,8 @@ pub fn compile_subst_flags(
 
             'p' => {
                 subst.print_flag = true;
+                // 'p' is applied before 'e' iff 'e' has not been seen yet.
+                subst.p_before_e = !subst.execute;
                 line.advance();
             }
 

--- a/src/sed/delimited_parser.rs
+++ b/src/sed/delimited_parser.rs
@@ -157,7 +157,7 @@ pub fn parse_char_escape(line: &mut ScriptCharProvider) -> Option<char> {
         }
 
         'U' => {
-            // Short Unicode escape \UXXXXXXXX (exactly eight heax digits)
+            // Short Unicode escape \UXXXXXXXX (exactly eight hex digits)
             line.advance(); // move past 'x'
             match parse_numeric_escape(line, |c| c.is_ascii_hexdigit(), 8, 16) {
                 Some(decoded) => Some(decoded),

--- a/src/sed/processor.rs
+++ b/src/sed/processor.rs
@@ -223,7 +223,7 @@ fn shell_stdout(cmd: &str) -> io::Result<Vec<u8>> {
     let mut child = shell_command(cmd)
         .stdout(std::process::Stdio::piped())
         .spawn()?;
-    let mut stdout = child.stdout.take().expect("stdout was piped");
+    let mut stdout = child.stdout.take().expect("stdout should be piped");
     let mut buf = Vec::new();
     stdout.read_to_end(&mut buf)?;
     child.wait()?;
@@ -232,7 +232,7 @@ fn shell_stdout(cmd: &str) -> io::Result<Vec<u8>> {
 
 /// Execute the pattern space as a shell command, replacing its contents
 /// with the command's standard output, minus one trailing newline.
-fn execute_pattern_as_shell(
+fn execute_pattern_as_shell_command(
     pattern: &mut IOChunk,
     command: &Command,
     context: &mut ProcessingContext,
@@ -246,12 +246,23 @@ fn execute_pattern_as_shell(
         )
         .unwrap_err()
     })?;
-    let mut shell_out = String::from_utf8_lossy(&stdout_bytes).into_owned();
-    if shell_out.ends_with("\r\n") {
-        // On windows, both return carriage and newline characters are used
-        shell_out.truncate(shell_out.len() - 2);
-    } else if shell_out.ends_with('\n') {
-        // Strip the trailing newline, as GNU sed does
+    let mut shell_out = String::from_utf8(stdout_bytes).map_err(|e| {
+        input_runtime_error::<()>(
+            &command.location,
+            context,
+            format!("shell command output is not valid UTF-8: {e}"),
+        )
+        .unwrap_err()
+    })?;
+    #[cfg(windows)]
+    {
+        if shell_out.ends_with("\r\n") {
+            // On Windows a trailing \r\n is the line terminator; strip both.
+            shell_out.truncate(shell_out.len() - 2);
+        }
+    }
+    // Unix (and some Windows tool) has the trailing \n. Strip it, as GNU sed does.
+    if shell_out.ends_with('\n') {
         shell_out.pop();
     }
     pattern.set_to_string(shell_out, pattern.is_newline_terminated());
@@ -371,7 +382,7 @@ fn substitute(
 
         // Execute the pattern space as a shell command if the 'e' flag is set
         if sub.execute {
-            execute_pattern_as_shell(pattern, command, context)?;
+            execute_pattern_as_shell_command(pattern, command, context)?;
         }
 
         if sub.print_flag {
@@ -609,7 +620,7 @@ fn process_file(
                 }
                 'e' => match &command.data {
                     CommandData::None => {
-                        execute_pattern_as_shell(&mut pattern, &command, context)?;
+                        execute_pattern_as_shell_command(&mut pattern, &command, context)?;
                     }
                     CommandData::Text(cmd_str) => {
                         let stdout_bytes = shell_stdout(cmd_str).map_err(|e| {
@@ -620,7 +631,15 @@ fn process_file(
                             )
                             .unwrap_err()
                         })?;
-                        output.write_str(String::from_utf8_lossy(&stdout_bytes).into_owned())?;
+                        let shell_out = String::from_utf8(stdout_bytes).map_err(|e| {
+                            input_runtime_error::<()>(
+                                &command.location,
+                                context,
+                                format!("shell command output is not valid UTF-8: {e}"),
+                            )
+                            .unwrap_err()
+                        })?;
+                        output.write_str(shell_out)?;
                     }
                     _ => panic!("invalid 'e' command data"),
                 },

--- a/src/sed/processor.rs
+++ b/src/sed/processor.rs
@@ -19,7 +19,7 @@ use crate::sed::named_writer;
 
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::io::{self, IsTerminal};
+use std::io::{self, IsTerminal, Read};
 use std::path::PathBuf;
 use std::rc::Rc;
 use uucore::display::Quotable;
@@ -215,6 +215,49 @@ fn shell_command(_cmd: &str) -> std::process::Command {
     unimplemented!("the 'e' substitute flag requires a platform shell (/bin/sh or cmd.exe)");
 }
 
+/// Run `cmd` in a shell, returning its standard output. The child's
+/// standard error is left connected to this process's own, matching GNU
+/// sed's behavior of letting shell errors surface directly rather than
+/// being silently captured.
+fn shell_stdout(cmd: &str) -> io::Result<Vec<u8>> {
+    let mut child = shell_command(cmd)
+        .stdout(std::process::Stdio::piped())
+        .spawn()?;
+    let mut stdout = child.stdout.take().expect("stdout was piped");
+    let mut buf = Vec::new();
+    stdout.read_to_end(&mut buf)?;
+    child.wait()?;
+    Ok(buf)
+}
+
+/// Execute the pattern space as a shell command, replacing its contents
+/// with the command's standard output, minus one trailing newline.
+fn execute_pattern_as_shell(
+    pattern: &mut IOChunk,
+    command: &Command,
+    context: &mut ProcessingContext,
+) -> UResult<()> {
+    let cmd_str = pattern.as_str()?.to_string();
+    let stdout_bytes = shell_stdout(&cmd_str).map_err(|e| {
+        input_runtime_error::<()>(
+            &command.location,
+            context,
+            format!("failed to execute shell command: {e}"),
+        )
+        .unwrap_err()
+    })?;
+    let mut shell_out = String::from_utf8_lossy(&stdout_bytes).into_owned();
+    if shell_out.ends_with("\r\n") {
+        // On windows, both return carriage and newline characters are used
+        shell_out.truncate(shell_out.len() - 2);
+    } else if shell_out.ends_with('\n') {
+        // Strip the trailing newline, as GNU sed does
+        shell_out.pop();
+    }
+    pattern.set_to_string(shell_out, pattern.is_newline_terminated());
+    Ok(())
+}
+
 /// Perform the specified RE replacement in the provided pattern space.
 fn substitute(
     pattern: &mut IOChunk,
@@ -328,24 +371,7 @@ fn substitute(
 
         // Execute the pattern space as a shell command if the 'e' flag is set
         if sub.execute {
-            let cmd_str = pattern.as_str()?.to_string();
-            let output_bytes = shell_command(&cmd_str).output().map_err(|e| {
-                input_runtime_error::<()>(
-                    &command.location,
-                    context,
-                    format!("failed to execute shell command: {e}"),
-                )
-                .unwrap_err()
-            })?;
-            let mut shell_out = String::from_utf8_lossy(&output_bytes.stdout).into_owned();
-            if shell_out.ends_with("\r\n") {
-                // On windows, both return carriage and newline characters are used
-                shell_out.truncate(shell_out.len() - 2);
-            } else if shell_out.ends_with('\n') {
-                // Strip the trailing newline, as GNU sed does
-                shell_out.pop();
-            }
-            pattern.set_to_string(shell_out, pattern.is_newline_terminated());
+            execute_pattern_as_shell(pattern, command, context)?;
         }
 
         if sub.print_flag {
@@ -581,6 +607,23 @@ fn process_file(
                     pattern.clear();
                     break;
                 }
+                'e' => match &command.data {
+                    CommandData::None => {
+                        execute_pattern_as_shell(&mut pattern, &command, context)?;
+                    }
+                    CommandData::Text(cmd_str) => {
+                        let stdout_bytes = shell_stdout(cmd_str).map_err(|e| {
+                            input_runtime_error::<()>(
+                                &command.location,
+                                context,
+                                format!("failed to execute shell command: {e}"),
+                            )
+                            .unwrap_err()
+                        })?;
+                        output.write_str(String::from_utf8_lossy(&stdout_bytes).into_owned())?;
+                    }
+                    _ => panic!("invalid 'e' command data"),
+                },
                 'g' => {
                     // Replace pattern with the contents of the hold space.
                     pattern.set_to_string(context.hold.content.clone(), context.hold.has_newline);

--- a/src/sed/processor.rs
+++ b/src/sed/processor.rs
@@ -382,12 +382,16 @@ fn substitute(
 
         pattern.set_to_bytes(result, pattern.is_newline_terminated());
 
-        // Execute the pattern space as a shell command if the 'e' flag is set
+        // Apply the 'p' and 'e' flags in the order they were given: 'pe'
+        // prints the pre-execution text then executes, while 'ep' executes
+        // then prints the result.
+        if sub.print_flag && sub.p_before_e {
+            write_chunk(output, context, pattern)?;
+        }
         if sub.execute {
             execute_pattern_as_shell_command(pattern, command, context)?;
         }
-
-        if sub.print_flag {
+        if sub.print_flag && !sub.p_before_e {
             write_chunk(output, context, pattern)?;
         }
 

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -633,6 +633,211 @@ fn test_subst_e_flag_no_match_no_exec() {
 }
 
 ////////////////////////////////////////////////////////////
+// e command (execute)
+#[test]
+fn test_e_command_with_arg_basic() {
+    // With an argument, the command runs immediately and its output is
+    // written to the stream before the (unmodified) pattern space.
+    new_ucmd!()
+        .arg("e echo hi")
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("hi\na\n");
+}
+
+#[test]
+fn test_e_command_with_arg_no_space_required() {
+    // No whitespace is required between 'e' and its argument.
+    new_ucmd!()
+        .arg("eecho hi")
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("hi\na\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_e_command_with_arg_runs_real_shell_command() -> Result<(), Box<dyn std::error::Error>> {
+    // The argument is executed and not just its output captured.
+    // Verify a real filesystem side effect, matching GNU sed's own
+    // testsuite check for this command (testsuite/sandbox.sh).
+    let temp_dir = assert_fs::TempDir::new()?;
+    let marker = temp_dir.child("marker");
+
+    new_ucmd!()
+        .arg(format!("etouch {}", marker.path().display()))
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("a\n");
+
+    assert!(marker.path().exists());
+    Ok(())
+}
+
+#[test]
+fn test_e_command_no_arg_pattern_space_becomes_command() {
+    // With no argument, the pattern space itself is executed and replaced
+    // by the command's output.
+    new_ucmd!()
+        .arg("e")
+        .pipe_in("echo hi\n")
+        .succeeds()
+        .stdout_is("hi\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_e_command_no_arg_strips_one_trailing_newline() {
+    new_ucmd!()
+        .arg("e")
+        .pipe_in("printf \"a\\nb\\n\"\n")
+        .succeeds()
+        .stdout_is("a\nb\n");
+}
+
+#[test]
+fn test_e_command_with_arg_does_not_strip_trailing_newline() {
+    // Unlike the no-argument form, e-with-argument writes the child's
+    // stdout unmodified (echo's own newline is preserved).
+    new_ucmd!()
+        .arg("e echo hi")
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("hi\na\n");
+}
+
+#[test]
+fn test_e_command_with_address() {
+    new_ucmd!()
+        .arg("1e echo address")
+        .pipe_in("a\nb\n")
+        .succeeds()
+        .stdout_is("address\na\nb\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_e_command_semicolon_is_part_of_argument() {
+    // Unlike most commands, ';' does not terminate e's argument.
+    // Rest of the line is consumed unconditionally, so the shell (not
+    // sed) is what splits on the ';' here.
+    new_ucmd!()
+        .arg("e echo hi; echo bye")
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("hi\nbye\na\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_e_command_recognized_escape_decoded() {
+    // Escape sequences in the argument are decoded by sed itself (\t is
+    // the tab character) before the shell ever sees them, same as a/c/i.
+    new_ucmd!()
+        .arg(r#"e echo "hi\tthere""#)
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("hi\tthere\na\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_e_command_unrecognized_escape_falls_back_to_literal() {
+    // '\;' is not a recognized escape, so the backslash is dropped and
+    // ';' is kept literally. It's then the shell's own ';' that splits
+    // the resulting single-line command into two statements.
+    new_ucmd!()
+        .arg(r"e echo hi\;there")
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("hi\na\n")
+        .stderr_contains("there");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_e_command_backslash_continuation() {
+    // A trailing backslash continues the argument onto the next script
+    // line, joined by an embedded newline. The shell then treats that
+    // as two separate statements.
+    new_ucmd!()
+        .arg("e echo hi \\\nthere")
+        .pipe_in("x\n")
+        .succeeds()
+        .stdout_is("hi\nx\n")
+        .stderr_contains("there");
+}
+
+#[test]
+fn test_e_command_dangling_backslash_falls_back_to_no_arg() {
+    // A leading backslash with nothing left to continue into at the end
+    // of the script is treated the same as no argument at all.
+    new_ucmd!()
+        .arg(r"e\")
+        .pipe_in("echo hi\n")
+        .succeeds()
+        .stdout_is("hi\n");
+}
+
+#[test]
+fn test_e_command_rejected_with_posix() {
+    new_ucmd!()
+        .args(&["--posix", "e echo hi"])
+        .fails()
+        .stderr_contains("not allowed with --posix or --sandbox");
+}
+
+#[test]
+fn test_e_command_rejected_with_sandbox() {
+    new_ucmd!()
+        .args(&["--sandbox", "e echo hi"])
+        .fails()
+        .stderr_contains("not allowed with --posix or --sandbox");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_e_command_rejected_with_sandbox_no_side_effect() -> Result<(), Box<dyn std::error::Error>> {
+    // Rejection happens at compile time, before any input is processed, so
+    // the shell command must never run.
+    let temp_dir = assert_fs::TempDir::new()?;
+    let marker = temp_dir.child("marker");
+
+    new_ucmd!()
+        .args(&[
+            "--sandbox",
+            "-e",
+            &format!("etouch {}", marker.path().display()),
+        ])
+        .pipe_in("a\n")
+        .fails();
+
+    assert!(!marker.path().exists());
+    Ok(())
+}
+
+#[test]
+fn test_e_command_with_arg_command_failure() {
+    // A failing command's own error goes to stderr. sed itself succeeds.
+    new_ucmd!()
+        .arg("e nonexistent_command")
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("a\n")
+        .stderr_contains("nonexistent_command");
+}
+
+#[test]
+fn test_e_command_no_arg_command_failure() {
+    new_ucmd!()
+        .arg("e")
+        .pipe_in("nonexistent_command\n")
+        .succeeds()
+        .stdout_is("\n")
+        .stderr_contains("nonexistent_command");
+}
+
+////////////////////////////////////////////////////////////
 // Transliteration: y
 check_output!(trans_simple, ["-e", r"y/0123456789/9876543210/", LINES1]);
 check_output!(

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -670,18 +670,30 @@ fn test_subst_e_flag_no_match_no_exec() {
 
 ////////////////////////////////////////////////////////////
 // e command (execute)
+// The with-argument form writes the shell's raw, unmodified output to the
+// stream, so its byte-exact terminator differs by platform: LF from /bin/sh
+// on Unix, CRLF from cmd.exe on Windows. sed's own pattern-space auto-print
+// always uses LF. Hence the parallel Unix/Windows tests below.
 #[cfg(unix)]
 #[test]
 fn test_e_command_with_arg_basic() {
     // With an argument, the command runs immediately and its output is
     // written to the stream before the (unmodified) pattern space.
-    // Unix-only: this asserts the shell's raw, unmodified output byte for
-    // byte, which is LF-terminated on Unix but CRLF-terminated on Windows.
     new_ucmd!()
         .arg("e echo hi")
         .pipe_in("a\n")
         .succeeds()
         .stdout_is("hi\na\n");
+}
+
+#[cfg(windows)]
+#[test]
+fn test_e_command_with_arg_basic() {
+    new_ucmd!()
+        .arg("e echo hi")
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("hi\r\na\n");
 }
 
 #[cfg(unix)]
@@ -693,6 +705,16 @@ fn test_e_command_with_arg_no_space_required() {
         .pipe_in("a\n")
         .succeeds()
         .stdout_is("hi\na\n");
+}
+
+#[cfg(windows)]
+#[test]
+fn test_e_command_with_arg_no_space_required() {
+    new_ucmd!()
+        .arg("eecho hi")
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("hi\r\na\n");
 }
 
 #[cfg(unix)]
@@ -747,6 +769,18 @@ fn test_e_command_with_arg_does_not_strip_trailing_newline() {
         .stdout_is("hi\na\n");
 }
 
+#[cfg(windows)]
+#[test]
+fn test_e_command_with_arg_does_not_strip_trailing_newline() {
+    // The preserved CRLF (rather than a stripped-then-LF "hi\n") is what
+    // proves the with-argument form leaves the child's output unmodified.
+    new_ucmd!()
+        .arg("e echo hi")
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("hi\r\na\n");
+}
+
 #[cfg(unix)]
 #[test]
 fn test_e_command_with_address() {
@@ -755,6 +789,16 @@ fn test_e_command_with_address() {
         .pipe_in("a\nb\n")
         .succeeds()
         .stdout_is("address\na\nb\n");
+}
+
+#[cfg(windows)]
+#[test]
+fn test_e_command_with_address() {
+    new_ucmd!()
+        .arg("1e echo address")
+        .pipe_in("a\nb\n")
+        .succeeds()
+        .stdout_is("address\r\na\nb\n");
 }
 
 #[cfg(unix)]

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -879,6 +879,34 @@ fn test_e_command_no_arg_command_failure() {
         .stderr_contains("nonexistent_command");
 }
 
+#[cfg(unix)]
+#[test]
+fn test_e_command_no_arg_non_utf8_output_errors() {
+    // Non-UTF-8 shell output is reported as a runtime error (exit 2)
+    // rather than silently mangled. The pattern space is passed to the
+    // shell verbatim, so the shell's printf emits the raw 0xff byte.
+    new_ucmd!()
+        .arg("e")
+        .pipe_in("printf '\\377'\n")
+        .fails()
+        .code_is(2)
+        .stderr_contains("not valid UTF-8");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_e_command_with_arg_non_utf8_output_errors() {
+    // Same for the with-argument form (a separate execution path). The
+    // doubled backslash survives sed's own escape decoding as a single
+    // one, so the shell's printf emits the raw 0xff byte.
+    new_ucmd!()
+        .arg(r"e printf '%b' '\\377'")
+        .pipe_in("a\n")
+        .fails()
+        .code_is(2)
+        .stderr_contains("not valid UTF-8");
+}
+
 ////////////////////////////////////////////////////////////
 // Transliteration: y
 check_output!(trans_simple, ["-e", r"y/0123456789/9876543210/", LINES1]);

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -895,7 +895,6 @@ fn test_e_command_rejected_with_sandbox_no_side_effect() -> Result<(), Box<dyn s
             "-e",
             &format!("etouch {}", marker.path().display()),
         ])
-        .pipe_in("a\n")
         .fails();
 
     assert!(!marker.path().exists());

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -634,10 +634,13 @@ fn test_subst_e_flag_no_match_no_exec() {
 
 ////////////////////////////////////////////////////////////
 // e command (execute)
+#[cfg(unix)]
 #[test]
 fn test_e_command_with_arg_basic() {
     // With an argument, the command runs immediately and its output is
     // written to the stream before the (unmodified) pattern space.
+    // Unix-only: this asserts the shell's raw, unmodified output byte for
+    // byte, which is LF-terminated on Unix but CRLF-terminated on Windows.
     new_ucmd!()
         .arg("e echo hi")
         .pipe_in("a\n")
@@ -645,6 +648,7 @@ fn test_e_command_with_arg_basic() {
         .stdout_is("hi\na\n");
 }
 
+#[cfg(unix)]
 #[test]
 fn test_e_command_with_arg_no_space_required() {
     // No whitespace is required between 'e' and its argument.
@@ -695,6 +699,7 @@ fn test_e_command_no_arg_strips_one_trailing_newline() {
         .stdout_is("a\nb\n");
 }
 
+#[cfg(unix)]
 #[test]
 fn test_e_command_with_arg_does_not_strip_trailing_newline() {
     // Unlike the no-argument form, e-with-argument writes the child's
@@ -706,6 +711,7 @@ fn test_e_command_with_arg_does_not_strip_trailing_newline() {
         .stdout_is("hi\na\n");
 }
 
+#[cfg(unix)]
 #[test]
 fn test_e_command_with_address() {
     new_ucmd!()

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -725,6 +725,29 @@ fn test_subst_e_flag_combined_with_g() {
     new_ucmd!().arg("s/x/echo y/ge").pipe_in("x\n").succeeds();
 }
 
+#[cfg(unix)]
+#[test]
+fn test_subst_flags_ep_execute_then_print() {
+    // 'ep': execute first, then prints the command's result.
+    new_ucmd!()
+        .arg("s/.*/echo hi/ep")
+        .pipe_in("x\n")
+        .succeeds()
+        .stdout_is("hi\nhi\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_subst_flags_pe_print_then_execute() {
+    // 'pe': prints the pre-execution text first, then execute. The 'p'
+    // and 'e' flags are applied in the order written, matching GNU sed.
+    new_ucmd!()
+        .arg("s/.*/echo hi/pe")
+        .pipe_in("x\n")
+        .succeeds()
+        .stdout_is("echo hi\nhi\n");
+}
+
 #[test]
 fn test_subst_e_flag_rejected_with_posix() {
     // e flag is rejected at compile time if --posix or --sandbox is provided.


### PR DESCRIPTION
Fixes #476.

Implements the standalone `e` command (a GNU extension). Supports the command with and without arguments.

Changes:

- Added the `e` command in compiler.rs/processor.rs, both forms (with argument, bare/pattern-space). Argument parsing reuses the same escape decoding and backslash continuation as a/c/i, as GNU sed's `e` argument follows the same syntax.
- Rejected under `--posix` and `--sandbox` at compile time.
- Fixed `e` and `s///e` to silently swallowing the child shell's stderr.
- Added 17 tests covering both command forms, addressing, ';' not separating the argument, escape decoding, backslash continuation, --posix/--sandbox rejection, and stderr surfacing on failure.

Irrelevant: fixed a typo found at `delimited_parser.rs`.