### PR TITLE
Improve GNU compatibility through byte processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,19 @@ cargo test
   sequences.
 
 ### Incompatibilities
-* The input is assumed to be valid UTF-8 (this includes 7-bit ASCII).
-  If the input is in another code page, consider converting it through UTF-8
-  in order to avoid errors on invalid UTF-8 sequences and for the correct
-  handling of regular expressions.
-  This _sed_ program can also handle arbitrary byte sequences if no part of the
-  input is treated as string.
+* Similarly to GNU _sed_, input is processed as raw bytes or as valid UTF-8
+  (this includes 7-bit ASCII) based on the locale as specified by the
+  `LC_ALL`, `LC_CTYPE`, and `LANG` environment variables,
+  with the default being byte processing.
+  However, in contrast with GNU _sed_, other locales (e.g. ISO-8859-1)
+  are not supported. If the input is in another code page or encoding
+  and requires locale-specific processing (e.g. ignore/map case,
+  character classes), consider converting it through UTF-8 to ensure
+  the correct handling of locale-specific regular expressions.
+  This _sed_ program can also handle arbitrary byte sequences
+  if no part of the input requires treating it as a Rust String.
+* Back-references aren't supported when input is processed as bytes
+  (`LC_ALL=C`).
 * The command will report an error and fail if duplicate labels are found
   in the script.
   This matches the BSD behavior. The GNU version accepts duplicate labels.

--- a/src/sed/command.rs
+++ b/src/sed/command.rs
@@ -52,6 +52,8 @@ pub struct ProcessingContext {
     pub last_file: bool,
     /// Stop processing further input.
     pub stop_processing: bool,
+    /// Whether sed operates on bytes or UTF-8 characters
+    pub character_mode: CharacterMode,
     /// Previously compiled RE, saved for reuse when specifying an empty RE
     pub saved_regex: Option<Regex>,
     /// Modification of input processing action
@@ -59,7 +61,7 @@ pub struct ProcessingContext {
     // command.
     pub input_action: Option<InputAction>,
     /// Hold space
-    pub hold: StringSpace,
+    pub hold: ByteSpace,
     /// Nesting of { } at compile time
     pub parsed_block_nesting: usize,
     /// Command associated with each label
@@ -75,14 +77,22 @@ pub struct ProcessingContext {
 #[derive(Clone, Debug)]
 /// Elements that shall be appended at the end of each command processing cycle
 pub enum AppendElement {
-    Text(Rc<str>), // The specified text string
-    Path(PathBuf), // The contents of the specified file path
+    Text(Rc<[u8]>), // The specified text bytes
+    Path(PathBuf),  // The contents of the specified file path
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+/// Whether sed operates on bytes or UTF-8 characters
+pub enum CharacterMode {
+    Byte, // Interpret data as arbitrary bytes (C/POSIX locale).
+    #[default]
+    Utf8, // Interpret data as UTF-8 characters (UTF-8 locale).
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
-/// A space mirroring IOChunk, but only with a String
-pub struct StringSpace {
-    pub content: String,   // Line content without newline
+/// A space mirroring IOChunk without mmap-backed storage.
+pub struct ByteSpace {
+    pub content: Vec<u8>,  // Line content without newline
     pub has_newline: bool, // True if \n-terminated
 }
 
@@ -100,9 +110,9 @@ pub enum Address {
 #[derive(Debug)]
 /// A single part of an RE replacement
 pub enum ReplacementPart {
-    Literal(String), // Normal text
-    WholeMatch,      // &
-    Group(u32),      // \1 to \9
+    Literal(Vec<u8>), // Normal text
+    WholeMatch,       // &
+    Group(u32),       // \1 to \9
 }
 
 // The maximum value allowed in regex quantifier
@@ -152,8 +162,8 @@ impl ReplacementTemplate {
     /// let result = regex.replace_all(input, |caps: &Captures| {
     ///    template.apply_captures(&command, caps) });
     /// Returns an error if a backreference in the template was not matched by the RE.
-    pub fn apply_captures(&self, command: &Command, caps: &Captures) -> UResult<String> {
-        let mut result = String::new();
+    pub fn apply_captures(&self, command: &Command, caps: &Captures) -> UResult<Vec<u8>> {
+        let mut result = Vec::new();
 
         // Invalid group numbers may end here through (unkown at compile time)
         // reused REs.
@@ -169,15 +179,17 @@ impl ReplacementTemplate {
 
         for part in &self.parts {
             match part {
-                ReplacementPart::Literal(s) => result.push_str(s),
+                ReplacementPart::Literal(s) => result.extend_from_slice(s),
 
                 ReplacementPart::WholeMatch => {
-                    result.push_str(caps.get(0)?.map(|m| m.as_str()).unwrap_or_default());
+                    result
+                        .extend_from_slice(caps.get(0)?.map(|m| m.as_bytes()).unwrap_or_default());
                 }
 
                 ReplacementPart::Group(n) => {
                     let i: usize = (*n).try_into().unwrap();
-                    result.push_str(caps.get(i)?.map(|m| m.as_str()).unwrap_or_default());
+                    result
+                        .extend_from_slice(caps.get(i)?.map(|m| m.as_bytes()).unwrap_or_default());
                 }
             }
         }
@@ -186,14 +198,14 @@ impl ReplacementTemplate {
     }
 
     /// Apply the template to the given RE single match.
-    pub fn apply_match(&self, m: &Match) -> String {
-        let mut result = String::new();
+    pub fn apply_match(&self, m: &Match) -> Vec<u8> {
+        let mut result = Vec::new();
 
         for part in &self.parts {
             match part {
-                ReplacementPart::Literal(s) => result.push_str(s),
+                ReplacementPart::Literal(s) => result.extend_from_slice(s),
 
-                ReplacementPart::WholeMatch => result.push_str(m.as_str()),
+                ReplacementPart::WholeMatch => result.extend_from_slice(m.as_bytes()),
 
                 ReplacementPart::Group(_) => {
                     panic!("unexpected Regex group replacement")
@@ -217,6 +229,13 @@ pub struct Substitution {
     pub write_file: Option<Rc<RefCell<NamedWriter>>>, // Writer to file if 'w' flag is used
 }
 
+#[derive(Debug, PartialEq, Eq)]
+/// Result of parsing a transliteration string in byte or character mode.
+pub enum ParsedTransliteration {
+    Bytes(Vec<u8>),
+    Text(String),
+}
+
 /// The block of the first and most common Unicode characters:
 /// ASCII, Latin Extended, Greek, Curillic, Coptic, Arabic, etc.
 /// It comprises all UCS-2 characters.  We use a fast lookup array for these.
@@ -225,20 +244,28 @@ const COMMON_UNICODE: usize = 2048;
 #[derive(Debug)]
 /// Transliteration command (y)
 pub struct Transliteration {
-    fast: [char; COMMON_UNICODE],
-    slow: HashMap<char, char>,
+    byte_fast: [u8; 256],
+    unicode_fast: [char; COMMON_UNICODE],
+    unicode_slow: HashMap<char, char>,
+    pub(crate) is_byte_identity: bool,
 }
 
 impl Default for Transliteration {
     /// Create a new Transliteration with identity mapping for the fast-path.
     fn default() -> Self {
-        let mut fast = ['\0'; COMMON_UNICODE];
+        let mut fast = [0u8; 256];
         for (i, slot) in fast.iter_mut().enumerate() {
+            *slot = i as u8;
+        }
+        let mut unicode_fast = ['\0'; COMMON_UNICODE];
+        for (i, slot) in unicode_fast.iter_mut().enumerate() {
             *slot = char::from_u32(i as u32).unwrap_or('\0');
         }
         Self {
-            fast,
-            slow: HashMap::new(),
+            byte_fast: fast,
+            unicode_fast,
+            unicode_slow: HashMap::new(),
+            is_byte_identity: true,
         }
     }
 }
@@ -253,24 +280,43 @@ impl Transliteration {
         result
     }
 
+    /// Create through byte mappings from `source` to `target`.
+    pub fn from_bytes(source: &[u8], target: &[u8]) -> Self {
+        let mut result = Self::default();
+        for (&from, &to) in source.iter().zip(target) {
+            result.byte_fast[from as usize] = to;
+        }
+        result
+    }
+
     /// Set a transliteration mapping from one character to another.
     fn insert(&mut self, from: char, to: char) {
         let cp = from as usize;
         if cp < COMMON_UNICODE {
-            self.fast[cp] = to;
+            self.unicode_fast[cp] = to;
         } else {
-            self.slow.insert(from, to);
+            self.unicode_slow.insert(from, to);
+        }
+        if from.is_ascii() && to.is_ascii() {
+            self.byte_fast[from as usize] = to as u8;
+        } else {
+            self.is_byte_identity = false;
         }
     }
 
     /// Look up a character transliteration.
-    pub fn lookup(&self, ch: char) -> char {
+    pub fn lookup_char(&self, ch: char) -> char {
         let cp = ch as usize;
         if cp < COMMON_UNICODE {
-            self.fast[cp]
+            self.unicode_fast[cp]
         } else {
-            self.slow.get(&ch).copied().unwrap_or(ch)
+            self.unicode_slow.get(&ch).copied().unwrap_or(ch)
         }
+    }
+
+    /// Fast byte lookup for pure ASCII transliterations.
+    pub fn lookup_byte(&self, byte: u8) -> u8 {
+        self.byte_fast[byte as usize]
     }
 }
 
@@ -323,7 +369,7 @@ pub enum CommandData {
     NamedWriter(Rc<RefCell<NamedWriter>>),      // File output for 'w'
     Number(usize),                              // Number for 'l', 'q', 'Q' (GNU)
     Substitution(Box<Substitution>),            // Substitute command 's'
-    Text(Rc<str>),                              // Text for 'a', 'c', 'i'
+    Text(Rc<[u8]>),                             // Text for 'a', 'c', 'i'
     Transliteration(Box<Transliteration>),      // Transliteration command 'y'
 }
 
@@ -340,7 +386,7 @@ pub struct InputAction {
     /// Next command to execute (rather than commands from start)
     pub next_command: Option<Rc<RefCell<Command>>>,
     /// Data to prepend to the read contents
-    pub prepend: String,
+    pub prepend: Vec<u8>,
 }
 
 #[cfg(test)]
@@ -350,7 +396,7 @@ mod tests {
 
     // Return the captures for the RE applied to the specified string
     fn caps_for<'a>(re: &str, chunk: &'a mut IOChunk) -> Captures<'a> {
-        Regex::new(re)
+        Regex::new(re, CharacterMode::Utf8)
             .unwrap()
             .captures(chunk)
             .unwrap()
@@ -366,26 +412,26 @@ mod tests {
         let cmd = Command::default();
 
         let result = template.apply_captures(&cmd, &caps).unwrap();
-        assert_eq!(result, "");
+        assert_eq!(result, b"");
     }
 
     #[test]
     // s/abc/hello/
     fn test_literal_only() {
-        let template = ReplacementTemplate::new(vec![ReplacementPart::Literal("hello".into())]);
+        let template = ReplacementTemplate::new(vec![ReplacementPart::Literal(b"hello".to_vec())]);
         let input = &mut IOChunk::new_from_str("abc");
         let caps = caps_for("abc", input);
         let cmd = Command::default();
 
         let result = template.apply_captures(&cmd, &caps).unwrap();
-        assert_eq!(result, "hello");
+        assert_eq!(result, b"hello");
     }
 
     #[test]
     // s/foo\d+/got: &/
     fn test_whole_match() {
         let template = ReplacementTemplate::new(vec![
-            ReplacementPart::Literal("got: ".into()),
+            ReplacementPart::Literal(b"got: ".to_vec()),
             ReplacementPart::WholeMatch,
         ]);
         let input = &mut IOChunk::new_from_str("foo42");
@@ -393,14 +439,26 @@ mod tests {
         let cmd = Command::default();
 
         let result = template.apply_captures(&cmd, &caps).unwrap();
-        assert_eq!(result, "got: foo42");
+        assert_eq!(result, b"got: foo42");
+    }
+
+    #[test]
+    fn test_apply_match_uses_matched_bytes() {
+        let template = ReplacementTemplate::new(vec![
+            ReplacementPart::Literal(b"<".to_vec()),
+            ReplacementPart::WholeMatch,
+            ReplacementPart::Literal(b">".to_vec()),
+        ]);
+        let m = Match::from_bytes(1, 3, b"\xE9x");
+
+        assert_eq!(template.apply_match(&m), b"<\xE9x>");
     }
 
     #[test]
     // s/foo(\d+)/number: \1/
     fn test_backreference() {
         let template = ReplacementTemplate::new(vec![
-            ReplacementPart::Literal("number: ".into()),
+            ReplacementPart::Literal(b"number: ".to_vec()),
             ReplacementPart::Group(1),
         ]);
         let input = &mut IOChunk::new_from_str("foo42");
@@ -408,16 +466,16 @@ mod tests {
         let cmd = Command::default();
 
         let result = template.apply_captures(&cmd, &caps).unwrap();
-        assert_eq!(result, "number: 42");
+        assert_eq!(result, b"number: 42");
     }
 
     #[test]
     // s/(\w+):(\d+)/key: \1, value: \2/
     fn test_multiple_parts() {
         let template = ReplacementTemplate::new(vec![
-            ReplacementPart::Literal("key: ".into()),
+            ReplacementPart::Literal(b"key: ".to_vec()),
             ReplacementPart::Group(1),
-            ReplacementPart::Literal(", value: ".into()),
+            ReplacementPart::Literal(b", value: ".to_vec()),
             ReplacementPart::Group(2),
         ]);
         let input = &mut IOChunk::new_from_str("x:123");
@@ -425,16 +483,16 @@ mod tests {
         let cmd = Command::default();
 
         let result = template.apply_captures(&cmd, &caps).unwrap();
-        assert_eq!(result, "key: x, value: 123");
+        assert_eq!(result, b"key: x, value: 123");
     }
 
     #[test]
     // s/(\w+):(\d+)/key: \1, value: \3/
     fn test_invalid_group() {
         let template = ReplacementTemplate::new(vec![
-            ReplacementPart::Literal("key: ".into()),
+            ReplacementPart::Literal(b"key: ".to_vec()),
             ReplacementPart::Group(1),
-            ReplacementPart::Literal(", value: ".into()),
+            ReplacementPart::Literal(b", value: ".to_vec()),
             ReplacementPart::Group(3),
         ]);
         let input = &mut IOChunk::new_from_str("x:123");
@@ -452,11 +510,11 @@ mod tests {
     #[test]
     fn test_max_group_number_with_groups() {
         let template = ReplacementTemplate::new(vec![
-            ReplacementPart::Literal("a".into()),
+            ReplacementPart::Literal(b"a".to_vec()),
             ReplacementPart::Group(2),
             ReplacementPart::WholeMatch,
             ReplacementPart::Group(5),
-            ReplacementPart::Literal("z".into()),
+            ReplacementPart::Literal(b"z".to_vec()),
         ]);
         assert_eq!(template.max_group_number, 5);
     }
@@ -464,9 +522,9 @@ mod tests {
     #[test]
     fn test_max_group_number_without_groups() {
         let template = ReplacementTemplate::new(vec![
-            ReplacementPart::Literal("no".into()),
+            ReplacementPart::Literal(b"no".to_vec()),
             ReplacementPart::WholeMatch,
-            ReplacementPart::Literal("groups".into()),
+            ReplacementPart::Literal(b"groups".to_vec()),
         ]);
         assert_eq!(template.max_group_number, 0);
     }
@@ -476,16 +534,31 @@ mod tests {
     #[test]
     fn test_identity_lookup_fast_path() {
         let t = Transliteration::default();
-        assert_eq!(t.lookup('A'), 'A');
-        assert_eq!(t.lookup('z'), 'z');
-        assert_eq!(t.lookup('\u{07FF}'), '\u{07FF}'); // highest 2-byte UTF-8 char
+        assert_eq!(t.lookup_char('A'), 'A');
+        assert_eq!(t.lookup_char('z'), 'z');
+        assert_eq!(t.lookup_char('\u{07FF}'), '\u{07FF}'); // highest 2-byte UTF-8 char
     }
 
     #[test]
     fn test_identity_lookup_slow_path() {
         let t = Transliteration::default();
-        assert_eq!(t.lookup('\u{0800}'), '\u{0800}'); // just outside fast path
-        assert_eq!(t.lookup('\u{1F600}'), '\u{1F600}'); // 😀
+        assert_eq!(t.lookup_char('\u{0800}'), '\u{0800}'); // just outside fast path
+        assert_eq!(t.lookup_char('\u{1F600}'), '\u{1F600}'); // 😀
+    }
+
+    #[test]
+    fn test_from_bytes_and_lookup_byte() {
+        let t = Transliteration::from_bytes(b"a\xE9", b"Z!");
+        assert_eq!(t.lookup_byte(b'a'), b'Z');
+        assert_eq!(t.lookup_byte(0xE9), b'!');
+        assert_eq!(t.lookup_byte(b'b'), b'b');
+    }
+
+    #[test]
+    fn test_is_byte_identity_tracks_non_ascii_character_mappings() {
+        assert!(Transliteration::from_strings("ab", "xy").is_byte_identity);
+        assert!(!Transliteration::from_strings("aé", "xy").is_byte_identity);
+        assert!(!Transliteration::from_strings("ab", "xé").is_byte_identity);
     }
 
     #[test]
@@ -493,26 +566,26 @@ mod tests {
         let mut t = Transliteration::default();
         t.insert('a', 'α');
         t.insert('b', 'β');
-        assert_eq!(t.lookup('a'), 'α');
-        assert_eq!(t.lookup('b'), 'β');
-        assert_eq!(t.lookup('c'), 'c'); // unchanged
+        assert_eq!(t.lookup_char('a'), 'α');
+        assert_eq!(t.lookup_char('b'), 'β');
+        assert_eq!(t.lookup_char('c'), 'c'); // unchanged
     }
 
     #[test]
     fn test_insert_and_lookup_slow_path() {
         let mut t = Transliteration::default();
         t.insert('🦀', 'c'); // U+1F980 Crab emoji -> 'c'
-        assert_eq!(t.lookup('🦀'), 'c');
-        assert_eq!(t.lookup('🦁'), '🦁'); // unchanged
+        assert_eq!(t.lookup_char('🦀'), 'c');
+        assert_eq!(t.lookup_char('🦁'), '🦁'); // unchanged
     }
 
     #[test]
     fn test_overwrite_mapping() {
         let mut t = Transliteration::default();
         t.insert('x', '1');
-        assert_eq!(t.lookup('x'), '1');
+        assert_eq!(t.lookup_char('x'), '1');
         t.insert('x', '2');
-        assert_eq!(t.lookup('x'), '2');
+        assert_eq!(t.lookup_char('x'), '2');
     }
 
     #[test]
@@ -523,8 +596,8 @@ mod tests {
                 t.insert(ch, ' ');
             }
         }
-        assert_eq!(t.lookup('A'), ' ');
-        assert_eq!(t.lookup('\u{07FF}'), ' ');
+        assert_eq!(t.lookup_char('A'), ' ');
+        assert_eq!(t.lookup_char('\u{07FF}'), ' ');
     }
 
     // from_strings
@@ -532,11 +605,11 @@ mod tests {
     fn test_basic_transliteration() {
         let t = Transliteration::from_strings("abcδ", "1234");
 
-        assert_eq!(t.lookup('a'), '1');
-        assert_eq!(t.lookup('b'), '2');
-        assert_eq!(t.lookup('c'), '3');
-        assert_eq!(t.lookup('δ'), '4');
-        assert_eq!(t.lookup('e'), 'e'); // not mapped, fallback
+        assert_eq!(t.lookup_char('a'), '1');
+        assert_eq!(t.lookup_char('b'), '2');
+        assert_eq!(t.lookup_char('c'), '3');
+        assert_eq!(t.lookup_char('δ'), '4');
+        assert_eq!(t.lookup_char('e'), 'e'); // not mapped, fallback
     }
 
     #[test]
@@ -545,16 +618,16 @@ mod tests {
         let target = "e文c";
         let t = Transliteration::from_strings(source, target);
 
-        assert_eq!(t.lookup('é'), 'e');
-        assert_eq!(t.lookup('漢'), '文');
-        assert_eq!(t.lookup('🦀'), 'c');
-        assert_eq!(t.lookup('x'), 'x'); // fast fallback
-        assert_eq!(t.lookup('文'), '文'); // slow fallback
+        assert_eq!(t.lookup_char('é'), 'e');
+        assert_eq!(t.lookup_char('漢'), '文');
+        assert_eq!(t.lookup_char('🦀'), 'c');
+        assert_eq!(t.lookup_char('x'), 'x'); // fast fallback
+        assert_eq!(t.lookup_char('文'), '文'); // slow fallback
     }
 
     #[test]
     fn test_overwrite_fast_path() {
         let t = Transliteration::from_strings("aa", "12");
-        assert_eq!(t.lookup('a'), '2'); // last mapping wins
+        assert_eq!(t.lookup_char('a'), '2'); // last mapping wins
     }
 }

--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -9,10 +9,13 @@
 // file that was distributed with this source code.
 
 use crate::sed::command::{
-    Address, Command, CommandData, ProcessingContext, RegexMode, ReplacementPart,
-    ReplacementTemplate, Substitution, Transliteration,
+    Address, CharacterMode, Command, CommandData, ParsedTransliteration, ProcessingContext,
+    RegexMode, ReplacementPart, ReplacementTemplate, Substitution, Transliteration,
 };
-use crate::sed::delimited_parser::{parse_char_escape, parse_regex, parse_transliteration};
+use crate::sed::delimited_parser::{
+    os_string_from_bytes, parse_char_escape, parse_regex_for_mode, parse_transliteration_for_mode,
+    push_script_char,
+};
 use crate::sed::error_handling::{ScriptLocation, compilation_error, semantic_error};
 use crate::sed::fast_regex::Regex;
 use crate::sed::named_writer::NamedWriter;
@@ -34,6 +37,7 @@ const ERR_ADDRESS_0_USAGE: &str =
 const ERR_SANDBOX: &str = "command not allowed with --sandbox";
 
 const ERR_UNKNOWN_OPTION_TO_S: &str = "unknown option to 's'";
+const ERR_TRANSLITERATION_LENGTH: &str = "transliteration strings are not the same length";
 
 // Handling required after processing a command
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,6 +260,7 @@ fn compile_sequence(
     loop {
         line.eat_spaces();
 
+        // Special first-line comment disabling default output
         // According to POSIX: "If the first two characters in the script are
         // "#n", the default output shall be suppressed".
         if !line.eol()
@@ -273,13 +278,14 @@ fn compile_sequence(
             }
         }
 
+        // Empty lines and comments
         if line.eol() || line.current() == '#' {
             match lines.next_line()? {
                 None => {
                     return Ok(head);
                 }
-                Some(line_string) => {
-                    *line = ScriptCharProvider::new(&line_string);
+                Some(line_bytes) => {
+                    *line = ScriptCharProvider::new(line_bytes);
                 }
             }
             continue;
@@ -377,7 +383,7 @@ fn compile_address_range(
                         return compilation_error(
                             lines,
                             line,
-                            "~step can only be specified on numeric addresses",
+                            "~step can only be specified through numeric values",
                         );
                     }
                 }
@@ -415,20 +421,24 @@ fn compile_address_range(
 }
 
 /// Read the line's remaining characters as a file path and return it.
+// TODO Move to delimited_parser in separate commit.
 fn read_file_path(lines: &ScriptLineProvider, line: &mut ScriptCharProvider) -> UResult<PathBuf> {
     line.advance(); // Skip the command/w character
     line.eat_spaces(); // Skip any leading whitespace
 
-    let mut path = String::new();
+    let mut path = Vec::new();
     while !line.eol() {
-        path.push(line.current());
+        path.push(line.current_byte());
         line.advance();
     }
 
     if path.is_empty() {
         compilation_error(lines, line, "missing file path")
     } else {
-        Ok(PathBuf::from(path))
+        os_string_from_bytes(path).map(PathBuf::from).map_err(|e| {
+            compilation_error::<PathBuf>(lines, line, format!("invalid characters file path: {e}"))
+                .unwrap_err()
+        })
     }
 }
 
@@ -458,7 +468,7 @@ fn compile_address(
             } else {
                 RegexMode::Basic
             };
-            let re = parse_regex(lines, line, regex_mode)?;
+            let re = parse_regex_for_mode(lines, line, regex_mode, context.character_mode)?;
             // Skip over delimiter
             line.advance();
 
@@ -540,47 +550,50 @@ fn parse_command_ending(
     Ok(())
 }
 
-/// Convert a primitive BRE pattern to a safe ERE-compatible pattern string.
+/// Convert a primitive BRE pattern to a safe ERE-compatible pattern.
 /// - Replaces `\(`, `\)`, `\?`, `\+`, `\|`, `\{` and `\}` with `(`, `)`, `?`, `+`, `|`, `{` and `}`.
 /// - Puts single-digit back-references in non-capturing groups..
 /// - Escapes ERE-only metacharacters: `+ ? { } | ( )`.
-/// - Leaves all other characters as-is.
-fn bre_to_ere(pattern: &str) -> String {
-    let mut result = String::with_capacity(pattern.len());
-    let mut chars = pattern.chars().peekable();
+/// - Leaves all other bytes as-is.
+fn bre_to_ere(pattern: &[u8]) -> Vec<u8> {
+    let mut result = Vec::with_capacity(pattern.len());
+    let mut pos = 0;
 
     let mut at_beginning = true;
-    let mut previous: Option<char> = None;
-    while let Some(c) = chars.next() {
-        if c == '\\' {
-            match chars.peek() {
-                Some('(') => {
-                    chars.next();
-                    result.push('('); // Group start
+    let mut previous: Option<u8> = None;
+    while pos < pattern.len() {
+        let c = pattern[pos];
+        pos += 1;
+
+        if c == b'\\' {
+            match pattern.get(pos).copied() {
+                Some(b'(') => {
+                    pos += 1;
+                    result.push(b'('); // Group start
                 }
-                Some(')') => {
-                    chars.next();
-                    result.push(')'); // Group end
+                Some(b')') => {
+                    pos += 1;
+                    result.push(b')'); // Group end
                 }
-                Some('?') => {
-                    chars.next();
-                    result.push('?'); // Quantifier 0 or 1
+                Some(b'?') => {
+                    pos += 1;
+                    result.push(b'?'); // Quantifier 0 or 1
                 }
-                Some('+') => {
-                    chars.next();
-                    result.push('+'); // Quantifier 1 or more
+                Some(b'+') => {
+                    pos += 1;
+                    result.push(b'+'); // Quantifier 1 or more
                 }
-                Some('|') => {
-                    chars.next();
-                    result.push('|'); // Alternation operator
+                Some(b'|') => {
+                    pos += 1;
+                    result.push(b'|'); // Alternation operator
                 }
-                Some('{') => {
-                    chars.next();
-                    result.push('{'); // Brace quantifier start
+                Some(b'{') => {
+                    pos += 1;
+                    result.push(b'{'); // Brace quantifier start
                 }
-                Some('}') => {
-                    chars.next();
-                    result.push('}'); // Brace quantifier end
+                Some(b'}') => {
+                    pos += 1;
+                    result.push(b'}'); // Brace quantifier end
                 }
                 Some(v) if v.is_ascii_digit() => {
                     // Back-reference.  In sed BREs these are single-digit
@@ -589,28 +602,30 @@ fn bre_to_ere(pattern: &str) -> String {
                     // to avoid having the number extend beyond the single
                     // digit. Example: In sed \11 matches group 1 followed
                     // by '1', not group 11.
-                    result.push_str(&format!(r"(?:\{v})"));
-                    chars.next();
+                    result.extend_from_slice(b"(?:\\");
+                    result.push(v);
+                    result.push(b')');
+                    pos += 1;
                 }
-                Some(&next) => {
+                Some(next) => {
                     // Preserve other escaped characters.
-                    chars.next();
-                    result.push('\\');
+                    pos += 1;
+                    result.push(b'\\');
                     result.push(next);
                 }
                 None => {
                     // Trailing backslash; keep it.
-                    result.push('\\');
+                    result.push(b'\\');
                 }
             }
         } else {
             match c {
-                '+' | '?' | '{' | '}' | '|' | '(' | ')' => {
+                b'+' | b'?' | b'{' | b'}' | b'|' | b'(' | b')' => {
                     // Escape unsupported ERE metacharacters.
-                    result.push('\\');
+                    result.push(b'\\');
                     result.push(c);
                 }
-                '^' if !at_beginning && previous != Some('[') => {
+                b'^' if !at_beginning && previous != Some(b'[') => {
                     // In BREs ^ has special meaning at the beginning
                     // and as bracket negation.  This heuristic escapes
                     // all other uses, which per POSIX are valid in EREs.
@@ -618,12 +633,12 @@ fn bre_to_ere(pattern: &str) -> String {
                     // the 'a' prevents the expression "^b" from matching
                     // starting at the first character."
                     // POSIX 9.4.9 ERE Expression Anchoring
-                    result.push('\\');
+                    result.push(b'\\');
                     result.push(c);
                 }
-                '$' if chars.peek().is_some() => {
+                b'$' if pos < pattern.len() => {
                     // Similarly for $ appearing not at the end.
-                    result.push('\\');
+                    result.push(b'\\');
                     result.push(c);
                 }
                 _ => result.push(c),
@@ -642,51 +657,64 @@ fn bre_to_ere(pattern: &str) -> String {
 fn compile_regex(
     lines: &ScriptLineProvider,
     line: &ScriptCharProvider,
-    pattern: &str,
+    pattern: impl AsRef<[u8]>,
     context: &ProcessingContext,
     icase: bool,
     multiline: bool,
 ) -> UResult<Option<Regex>> {
+    let pattern = pattern.as_ref();
     if pattern.is_empty() {
         return Ok(None);
     }
 
     // Convert basic to extended regular expression if needed.
     let pattern = if context.regex_extended {
-        pattern
+        pattern.to_vec()
     } else {
-        &bre_to_ere(pattern)
+        bre_to_ere(pattern)
     };
 
-    let mut modifiers = String::new();
+    // Add any required modifiers.
+    let mut modifiers = Vec::new();
     if icase {
-        modifiers.push('i');
+        modifiers.push(b'i');
     }
     if multiline {
-        modifiers.push('m');
+        modifiers.push(b'm');
     }
     let pattern = if modifiers.is_empty() {
-        pattern.to_string()
+        pattern
     } else {
-        format!("(?{modifiers}){pattern}")
+        // Append modifiers.
+        let mut with_modifiers = Vec::with_capacity(pattern.len() + modifiers.len() + 3);
+        with_modifiers.extend_from_slice(b"(?");
+        with_modifiers.extend_from_slice(&modifiers);
+        with_modifiers.push(b')');
+        with_modifiers.extend_from_slice(&pattern);
+        with_modifiers
     };
 
     // Compile into engine.
-    let compiled = Regex::new(&pattern).map_err(|e| {
-        compilation_error::<Regex>(lines, line, format!("invalid regex '{pattern}': {e}"))
-            .unwrap_err()
+    let compiled = Regex::new(&pattern, context.character_mode).map_err(|e| {
+        compilation_error::<Regex>(
+            lines,
+            line,
+            format!("invalid regex '{}': {e}", String::from_utf8_lossy(&pattern)),
+        )
+        .unwrap_err()
     })?;
 
     Ok(Some(compiled))
 }
 
-/// Compile a regular expression replacement string.
+/// Compile a regular expression replacement string according to character mode.
 pub fn compile_replacement(
     lines: &mut ScriptLineProvider,
     line: &mut ScriptCharProvider,
+    character_mode: CharacterMode,
 ) -> UResult<ReplacementTemplate> {
     let mut parts = Vec::new();
-    let mut literal = String::new();
+    let mut literal = Vec::new();
 
     let delimiter = line.current();
     line.advance();
@@ -699,9 +727,9 @@ pub fn compile_replacement(
 
                     // Line input_action
                     if line.eol() {
-                        if let Some(next_line_string) = lines.next_line()? {
-                            literal.push('\n');
-                            *line = ScriptCharProvider::new(&next_line_string);
+                        if let Some(next_line) = lines.next_line()? {
+                            literal.push(b'\n');
+                            *line = ScriptCharProvider::new(next_line);
                             continue;
                         }
                         return compilation_error(
@@ -729,23 +757,23 @@ pub fn compile_replacement(
 
                         // Literal \ and &
                         '\\' | '&' => {
-                            literal.push(line.current());
+                            literal.push(line.current_byte());
                             line.advance();
                         }
 
                         // Literal delimiter
                         v if v == delimiter => {
-                            literal.push(line.current());
+                            literal.push(line.current_byte());
                             line.advance();
                         }
 
                         // other escape sequences
                         _ => {
                             if let Some(decoded) = parse_char_escape(line) {
-                                literal.push(decoded);
+                                push_script_char(&mut literal, decoded, character_mode);
                             } else {
-                                literal.push('\\');
-                                literal.push(line.current());
+                                literal.push(b'\\');
+                                literal.push(line.current_byte());
                                 line.advance();
                             }
                         }
@@ -776,16 +804,16 @@ pub fn compile_replacement(
                     return Ok(ReplacementTemplate::new(parts));
                 }
 
-                c => {
-                    literal.push(c);
+                _ => {
+                    literal.push(line.current_byte());
                     line.advance();
                 }
             }
         }
 
         // Fetch next line for continued replacement string
-        if let Some(next_line_string) = lines.next_line()? {
-            *line = ScriptCharProvider::new(&next_line_string);
+        if let Some(next_line) = lines.next_line()? {
+            *line = ScriptCharProvider::new(next_line);
         } else {
             return compilation_error(lines, line, "unterminated substitute replacement");
         }
@@ -815,10 +843,10 @@ fn compile_subst_command(
     } else {
         RegexMode::Basic
     };
-    let pattern = parse_regex(lines, line, regex_mode)?;
+    let pattern = parse_regex_for_mode(lines, line, regex_mode, context.character_mode)?;
     let mut subst = Box::new(Substitution::default());
 
-    subst.replacement = compile_replacement(lines, line)?;
+    subst.replacement = compile_replacement(lines, line, context.character_mode)?;
     compile_subst_flags(lines, line, &mut subst, context.posix, context.sandbox)?;
 
     if pattern.is_empty() && (subst.ignore_case || subst.multiline) {
@@ -863,7 +891,7 @@ fn compile_trans_command(
     lines: &mut ScriptLineProvider,
     line: &mut ScriptCharProvider,
     cmd: &mut Command,
-    _context: &mut ProcessingContext,
+    context: &mut ProcessingContext,
 ) -> UResult<CommandHandling> {
     line.advance(); // move past 'y'
 
@@ -876,17 +904,23 @@ fn compile_trans_command(
         );
     }
 
-    let source = parse_transliteration(lines, line)?;
-    let target = parse_transliteration(lines, line)?;
-    if source.chars().count() != target.chars().count() {
-        return compilation_error(
-            lines,
-            line,
-            "transliteration strings are not the same length",
-        );
-    }
-
-    let transliteration = Box::new(Transliteration::from_strings(&source, &target));
+    let source = parse_transliteration_for_mode(lines, line, context.character_mode)?;
+    let target = parse_transliteration_for_mode(lines, line, context.character_mode)?;
+    let transliteration = match (source, target) {
+        (ParsedTransliteration::Bytes(source), ParsedTransliteration::Bytes(target)) => {
+            if source.len() != target.len() {
+                return compilation_error(lines, line, ERR_TRANSLITERATION_LENGTH);
+            }
+            Box::new(Transliteration::from_bytes(&source, &target))
+        }
+        (ParsedTransliteration::Text(source), ParsedTransliteration::Text(target)) => {
+            if source.chars().count() != target.chars().count() {
+                return compilation_error(lines, line, ERR_TRANSLITERATION_LENGTH);
+            }
+            Box::new(Transliteration::from_strings(&source, &target))
+        }
+        _ => unreachable!("transliteration parser returned mixed modes"),
+    };
     cmd.data = CommandData::Transliteration(transliteration);
 
     line.advance(); // move past last delimiter
@@ -1216,7 +1250,7 @@ fn compile_text_command_gnu(
     lines: &mut ScriptLineProvider,
     line: &mut ScriptCharProvider,
     cmd: &mut Command,
-    _context: &mut ProcessingContext,
+    context: &mut ProcessingContext,
 ) -> UResult<CommandHandling> {
     // True after a \ at the end of a line
     let mut escaped_newline = false;
@@ -1236,15 +1270,15 @@ fn compile_text_command_gnu(
     }
 
     // Gather replacement text.  Stop on a non-escaped newline.
-    let mut text = String::new();
+    let mut text = Vec::new();
     'text_content: loop {
         if escaped_newline {
             match lines.next_line()? {
                 None => {
                     break 'text_content;
                 }
-                Some(line_string) => {
-                    *line = ScriptCharProvider::new(&line_string);
+                Some(line_bytes) => {
+                    *line = ScriptCharProvider::new(line_bytes);
                 }
             }
             escaped_newline = false;
@@ -1252,7 +1286,7 @@ fn compile_text_command_gnu(
 
         // Non-escaped newline
         if line.eol() {
-            text.push('\n');
+            text.push(b'\n');
             break 'text_content;
         }
 
@@ -1261,19 +1295,19 @@ fn compile_text_command_gnu(
 
             if line.eol() {
                 escaped_newline = true;
-                text.push('\n');
+                text.push(b'\n');
                 continue 'text_content;
             }
 
             if let Some(decoded) = parse_char_escape(line) {
-                text.push(decoded);
+                push_script_char(&mut text, decoded, context.character_mode);
             } else {
                 // Invalid escapes result in the escaped character.
-                text.push(line.current());
+                text.push(line.current_byte());
                 line.advance();
             }
         } else {
-            text.push(line.current());
+            text.push(line.current_byte());
             line.advance();
         }
     }
@@ -1311,15 +1345,15 @@ fn compile_text_command_posix(
         );
     }
 
-    let mut text = String::new();
+    let mut text = Vec::new();
     while let Some(line) = lines.next_line()? {
-        if line.ends_with('\\') {
+        if line.ends_with(b"\\") {
             // Line ends with \ to escape \n; remove the trailing \.
-            text.push_str(&line[..line.len() - 1]);
-            text.push('\n');
+            text.extend_from_slice(&line[..line.len() - 1]);
+            text.push(b'\n');
         } else {
-            text.push_str(&line);
-            text.push('\n');
+            text.extend_from_slice(&line);
+            text.push(b'\n');
             break;
         }
     }
@@ -1446,7 +1480,6 @@ fn get_cmd_spec(
 mod tests {
     use super::*;
     use crate::sed::fast_io::IOChunk;
-
     // Return an empty line provider and a char provider for the specified str.
     fn make_providers(input: &str) -> (ScriptLineProvider, ScriptCharProvider) {
         let lines = ScriptLineProvider::new(vec![]); // Empty for tests
@@ -1505,6 +1538,21 @@ mod tests {
         let (lines, line) = make_providers("123abc");
         let result = get_cmd_spec(&lines, &line, 'Z', false);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_command_ending_rejects_extra_characters() {
+        let (lines, mut chars) = make_providers("extra");
+        let mut cmd = Command {
+            code: 'p',
+            ..Default::default()
+        };
+
+        let err = parse_command_ending(&lines, &mut chars, &mut cmd).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("extra characters at the end of the p command")
+        );
     }
 
     // Utility to create a ScriptCharProvider from a &str
@@ -1843,6 +1891,18 @@ mod tests {
     }
 
     #[test]
+    fn test_compile_step_re_address_rejected() {
+        let (lines, mut chars) = make_providers("1~/x/");
+        let mut cmd = Rc::new(RefCell::new(Command::default()));
+        let err = compile_address_range(&lines, &mut chars, &mut cmd, &ctx()).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("~step can only be specified through numeric values")
+        );
+    }
+
+    #[test]
     fn test_compile_last_address() {
         let (lines, mut chars) = make_providers("$");
         let mut cmd = Rc::new(RefCell::new(Command::default()));
@@ -2111,44 +2171,53 @@ mod tests {
     }
 
     // compile_replacement
+
+    /// Compile a regular expression replacement string in UTF-8 mode.
+    fn compile_replacement_utf8(
+        lines: &mut ScriptLineProvider,
+        line: &mut ScriptCharProvider,
+    ) -> UResult<ReplacementTemplate> {
+        compile_replacement(lines, line, CharacterMode::Utf8)
+    }
+
     #[test]
     fn test_compile_replacement_literal() {
         let (mut lines, mut chars) = make_providers("/hello/");
-        let template = compile_replacement(&mut lines, &mut chars).unwrap();
+        let template = compile_replacement_utf8(&mut lines, &mut chars).unwrap();
 
         assert_eq!(template.parts.len(), 1);
-        assert!(matches!(&template.parts[0], ReplacementPart::Literal(s) if s == "hello"));
+        assert!(matches!(&template.parts[0], ReplacementPart::Literal(s) if s == b"hello"));
     }
 
     #[test]
     fn test_compile_replacement_escaped_delimiter() {
         let (mut lines, mut chars) = make_providers(r"/hell\/o/");
-        let template = compile_replacement(&mut lines, &mut chars).unwrap();
+        let template = compile_replacement_utf8(&mut lines, &mut chars).unwrap();
 
         assert_eq!(template.parts.len(), 1);
-        assert!(matches!(&template.parts[0], ReplacementPart::Literal(s) if s == "hell/o"));
+        assert!(matches!(&template.parts[0], ReplacementPart::Literal(s) if s == b"hell/o"));
     }
 
     #[test]
     fn test_compile_replacement_backrefs_and_literal() {
         let (mut lines, mut chars) = make_providers("/prefix \\1 and \\2/");
-        let template = compile_replacement(&mut lines, &mut chars).unwrap();
+        let template = compile_replacement_utf8(&mut lines, &mut chars).unwrap();
 
         assert_eq!(template.parts.len(), 4);
-        assert!(matches!(&template.parts[0], ReplacementPart::Literal(s) if s == "prefix "));
+        assert!(matches!(&template.parts[0], ReplacementPart::Literal(s) if s == b"prefix "));
         assert!(matches!(&template.parts[1], ReplacementPart::Group(1)));
-        assert!(matches!(&template.parts[2], ReplacementPart::Literal(s) if s == " and "));
+        assert!(matches!(&template.parts[2], ReplacementPart::Literal(s) if s == b" and "));
         assert!(matches!(&template.parts[3], ReplacementPart::Group(2)));
     }
 
     #[test]
     fn test_compile_replacement_whole_match() {
         let (mut lines, mut chars) = make_providers("/The match was: &/");
-        let template = compile_replacement(&mut lines, &mut chars).unwrap();
+        let template = compile_replacement_utf8(&mut lines, &mut chars).unwrap();
 
         assert_eq!(template.parts.len(), 2);
         assert!(
-            matches!(&template.parts[0], ReplacementPart::Literal(s) if s == "The match was: ")
+            matches!(&template.parts[0], ReplacementPart::Literal(s) if s == b"The match was: ")
         );
         assert!(matches!(&template.parts[1], ReplacementPart::WholeMatch));
     }
@@ -2156,11 +2225,11 @@ mod tests {
     #[test]
     fn test_compile_replacement_whole_match_synonym() {
         let (mut lines, mut chars) = make_providers(r"/The match was: \0/");
-        let template = compile_replacement(&mut lines, &mut chars).unwrap();
+        let template = compile_replacement_utf8(&mut lines, &mut chars).unwrap();
 
         assert_eq!(template.parts.len(), 2);
         assert!(
-            matches!(&template.parts[0], ReplacementPart::Literal(s) if s == "The match was: ")
+            matches!(&template.parts[0], ReplacementPart::Literal(s) if s == b"The match was: ")
         );
         assert!(matches!(&template.parts[1], ReplacementPart::WholeMatch));
     }
@@ -2168,23 +2237,44 @@ mod tests {
     #[test]
     fn test_compile_replacement_ampersand() {
         let (mut lines, mut chars) = make_providers("/Simon \\& Garfunkel/");
-        let template = compile_replacement(&mut lines, &mut chars).unwrap();
+        let template = compile_replacement_utf8(&mut lines, &mut chars).unwrap();
 
         assert_eq!(template.parts.len(), 1);
         assert!(
-            matches!(&template.parts[0], ReplacementPart::Literal(s) if s == "Simon & Garfunkel")
+            matches!(&template.parts[0], ReplacementPart::Literal(s) if s == b"Simon & Garfunkel")
         );
     }
 
     #[test]
     fn test_compile_replacement_escape_sequences() {
         let (mut lines, mut chars) = make_providers("/line\\nnewline\\tend/");
-        let template = compile_replacement(&mut lines, &mut chars).unwrap();
+        let template = compile_replacement_utf8(&mut lines, &mut chars).unwrap();
 
         assert_eq!(template.parts.len(), 1);
         assert!(matches!(
             &template.parts[0],
-            ReplacementPart::Literal(s) if s == "line\nnewline\tend"
+            ReplacementPart::Literal(s) if s == b"line\nnewline\tend"
+        ));
+    }
+
+    #[test]
+    fn test_compile_replacement_escape_byte_mode() {
+        let (mut lines, mut chars) = make_providers("/\\xE9/");
+        let template = compile_replacement(&mut lines, &mut chars, CharacterMode::Byte).unwrap();
+
+        assert_eq!(template.parts.len(), 1);
+        assert!(matches!(&template.parts[0], ReplacementPart::Literal(s) if s == b"\xE9"));
+    }
+
+    #[test]
+    fn test_compile_replacement_escape_utf8_mode() {
+        let (mut lines, mut chars) = make_providers("/\\xE9/");
+        let template = compile_replacement(&mut lines, &mut chars, CharacterMode::Utf8).unwrap();
+
+        assert_eq!(template.parts.len(), 1);
+        assert!(matches!(
+            &template.parts[0],
+            ReplacementPart::Literal(s) if s == "é".as_bytes()
         ));
     }
 
@@ -2196,14 +2286,67 @@ mod tests {
         ];
         let mut provider = ScriptLineProvider::new(script);
         let first_line = provider.next_line().unwrap().unwrap();
-        let mut chars = ScriptCharProvider::new(&first_line);
+        let mut chars = ScriptCharProvider::new(first_line);
 
-        let template = compile_replacement(&mut provider, &mut chars).unwrap();
+        let template = compile_replacement_utf8(&mut provider, &mut chars).unwrap();
         assert_eq!(template.parts.len(), 1);
         assert!(matches!(
             &template.parts[0],
-            ReplacementPart::Literal(s) if s == "first line\n continued"
+            ReplacementPart::Literal(s) if s == b"first line\n continued"
         ));
+    }
+
+    #[test]
+    fn test_compile_replacement_preserves_invalid_utf8_script_byte() {
+        let mut chars = ScriptCharProvider::new(b"/\xC2/");
+        let mut lines = ScriptLineProvider::new(vec![]);
+
+        let template = compile_replacement_utf8(&mut lines, &mut chars).unwrap();
+
+        assert_eq!(template.parts.len(), 1);
+        assert!(matches!(&template.parts[0], ReplacementPart::Literal(s) if s == b"\xC2"));
+    }
+
+    #[test]
+    fn test_compile_replacement_preserves_unknown_escape() {
+        let (mut lines, mut chars) = make_providers(r"/a\q/");
+        let template = compile_replacement_utf8(&mut lines, &mut chars).unwrap();
+
+        assert_eq!(template.parts.len(), 1);
+        assert!(matches!(&template.parts[0], ReplacementPart::Literal(s) if s == br"a\q"));
+    }
+
+    #[test]
+    fn test_compile_replacement_eof_after_backslash() {
+        let (mut lines, mut chars) = make_providers(r"/abc\");
+        let err = compile_replacement_utf8(&mut lines, &mut chars).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("unterminated substitute replacement (unexpected EOF)")
+        );
+    }
+
+    #[test]
+    fn test_compile_replacement_unescaped_newline() {
+        let (mut lines, mut chars) = make_providers("/abc\n/");
+        let err = compile_replacement_utf8(&mut lines, &mut chars).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("unescaped newline inside substitute replacement")
+        );
+    }
+
+    #[test]
+    fn test_compile_replacement_unterminated() {
+        let (mut lines, mut chars) = make_providers("/abc");
+        let err = compile_replacement_utf8(&mut lines, &mut chars).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("unterminated substitute replacement")
+        );
     }
 
     // compile_subst_flags
@@ -2296,7 +2439,7 @@ mod tests {
 
     #[test]
     fn test_compile_subst_flag_w_missing_filename() {
-        let (lines, mut chars) = make_providers("w ");
+        let (lines, mut chars) = make_providers("w ");
         let mut subst = Substitution::default();
 
         let err = compile_subst_flags(&lines, &mut chars, &mut subst, false, false).unwrap_err();
@@ -2420,7 +2563,7 @@ mod tests {
             CommandData::Substitution(subst) => {
                 assert_eq!(subst.replacement.parts.len(), 1);
                 assert!(
-                    matches!(&subst.replacement.parts[0], ReplacementPart::Literal(s) if s == "bar")
+                    matches!(&subst.replacement.parts[0], ReplacementPart::Literal(s) if s == b"bar")
                 );
             }
             _ => panic!("Expected CommandData::Substitution"),
@@ -2438,58 +2581,96 @@ mod tests {
         assert!(err.to_string().contains("invalid reference \\2"));
     }
 
+    #[test]
+    fn test_compile_subst_empty_re_rejects_modifiers() {
+        let (mut lines, mut chars) = make_providers("s//x/I");
+        let mut cmd = Command::default();
+        let mut context = ctx();
+
+        let err =
+            compile_subst_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot specify modifiers on an empty regular expression")
+        );
+    }
+
+    #[test]
+    fn test_compile_trans_command_sets_command_data() {
+        let (mut lines, mut chars) = make_providers("y/ab/xy/");
+        let mut cmd = Command::default();
+        let mut context = ProcessingContext {
+            character_mode: CharacterMode::Byte,
+            ..ctx()
+        };
+
+        compile_trans_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
+        match &cmd.data {
+            CommandData::Transliteration(trans) => {
+                assert_eq!(trans.lookup_byte(b'a'), b'x');
+                assert_eq!(trans.lookup_byte(b'b'), b'y');
+                assert_eq!(trans.lookup_byte(b'c'), b'c');
+            }
+            _ => panic!("Expected CommandData::Transliteration"),
+        }
+    }
+
     // bre_to_ere
+    fn bre_to_ere_string(pattern: &str) -> String {
+        String::from_utf8(bre_to_ere(pattern.as_bytes())).unwrap()
+    }
+
     #[test]
     fn test_bre_group_translation() {
-        assert_eq!(bre_to_ere(r"\(a\?b\+c\|\)"), "(a?b+c|)");
-        assert_eq!(bre_to_ere(r"a\(b\)c"), "a(b)c");
+        assert_eq!(bre_to_ere_string(r"\(a\?b\+c\|\)"), "(a?b+c|)");
+        assert_eq!(bre_to_ere_string(r"a\(b\)c"), "a(b)c");
     }
 
     #[test]
     fn test_bre_brace_quantifier_translation() {
-        assert_eq!(bre_to_ere(r"\{1,4\}"), "{1,4}");
+        assert_eq!(bre_to_ere_string(r"\{1,4\}"), "{1,4}");
     }
 
     #[test]
     fn test_ere_metacharacters_escaped() {
-        assert_eq!(bre_to_ere(r"a+b?c{1}|(d)"), r"a\+b\?c\{1\}\|\(d\)");
+        assert_eq!(bre_to_ere_string(r"a+b?c{1}|(d)"), r"a\+b\?c\{1\}\|\(d\)");
     }
 
     #[test]
     fn test_literal_backslashes_preserved() {
-        assert_eq!(bre_to_ere(r"foo\\bar"), r"foo\\bar");
-        assert_eq!(bre_to_ere(r"\."), r"\.");
+        assert_eq!(bre_to_ere_string(r"foo\\bar"), r"foo\\bar");
+        assert_eq!(bre_to_ere_string(r"\."), r"\.");
     }
 
     #[test]
     fn test_character_classes_unchanged() {
-        assert_eq!(bre_to_ere(r"[a-z]"), "[a-z]");
-        assert_eq!(bre_to_ere(r"[^0-9]"), "[^0-9]");
+        assert_eq!(bre_to_ere_string(r"[a-z]"), "[a-z]");
+        assert_eq!(bre_to_ere_string(r"[^0-9]"), "[^0-9]");
     }
 
     #[test]
     fn test_anchors_and_dot_and_star() {
-        assert_eq!(bre_to_ere(r"^a.*b$"), "^a.*b$");
+        assert_eq!(bre_to_ere_string(r"^a.*b$"), "^a.*b$");
     }
 
     #[test]
     fn test_trailing_backslash_is_preserved() {
-        assert_eq!(bre_to_ere(r"abc\"), r"abc\");
+        assert_eq!(bre_to_ere_string(r"abc\"), r"abc\");
     }
 
     #[test]
     fn test_caret_escaped_in_middle() {
-        assert_eq!(bre_to_ere(r"^a^[^x]c"), r"^a\^[^x]c");
+        assert_eq!(bre_to_ere_string(r"^a^[^x]c"), r"^a\^[^x]c");
     }
 
     #[test]
     fn test_dollar_escaped_in_middle() {
-        assert_eq!(bre_to_ere(r"a$c$"), r"a\$c$");
+        assert_eq!(bre_to_ere_string(r"a$c$"), r"a\$c$");
     }
 
     #[test]
     fn test_bre_back_reference() {
-        assert_eq!(bre_to_ere(r"\(.\)\1\(.\)\2"), r"(.)(?:\1)(.)(?:\2)");
+        assert_eq!(bre_to_ere_string(r"\(.\)\1\(.\)\2"), r"(.)(?:\1)(.)(?:\2)");
     }
 
     // patch_block_endings
@@ -2996,7 +3177,7 @@ mod tests {
         compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
         match &cmd.data {
             CommandData::Text(text) => {
-                assert_eq!(text.to_string(), "line1\n");
+                assert_eq!(text.as_ref(), b"line1\n");
             }
             _ => panic!("Expected CommandData::Text"),
         }
@@ -3015,7 +3196,7 @@ mod tests {
         compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
         match &cmd.data {
             CommandData::Text(text) => {
-                assert_eq!(text.to_string(), "line1\n");
+                assert_eq!(text.as_ref(), b"line1\n");
             }
             _ => panic!("Expected CommandData::Text"),
         }
@@ -3044,7 +3225,7 @@ mod tests {
         compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
         match &cmd.data {
             CommandData::Text(text) => {
-                assert_eq!(text.to_string(), "there\n");
+                assert_eq!(text.as_ref(), b"there\n");
             }
             _ => panic!("Expected CommandData::Text"),
         }
@@ -3060,7 +3241,7 @@ mod tests {
         compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
         match &cmd.data {
             CommandData::Text(text) => {
-                assert_eq!(text.to_string(), "there\n");
+                assert_eq!(text.as_ref(), b"there\n");
             }
             _ => panic!("Expected CommandData::Text"),
         }
@@ -3089,7 +3270,7 @@ mod tests {
         compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
         match &cmd.data {
             CommandData::Text(text) => {
-                assert_eq!(text.to_string(), "");
+                assert_eq!(text.as_ref(), b"");
             }
             _ => panic!("Expected CommandData::Text"),
         }
@@ -3105,7 +3286,7 @@ mod tests {
         compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
         match &cmd.data {
             CommandData::Text(text) => {
-                assert_eq!(text.to_string(), "tom\n");
+                assert_eq!(text.as_ref(), b"tom\n");
             }
             _ => panic!("Expected CommandData::Text"),
         }
@@ -3121,7 +3302,23 @@ mod tests {
         compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
         match &cmd.data {
             CommandData::Text(text) => {
-                assert_eq!(text.to_string(), ">helll\x08o\nto\nall\x07\n");
+                assert_eq!(text.as_ref(), b">helll\x08o\nto\nall\x07\n");
+            }
+            _ => panic!("Expected CommandData::Text"),
+        }
+    }
+
+    #[test]
+    fn test_compile_text_command_gnu_preserves_invalid_utf8_script_byte() {
+        let mut chars = ScriptCharProvider::new(b"a\\\xC2");
+        let mut lines = make_line_provider(&[]);
+        let mut cmd = Command::default();
+        let mut context = ProcessingContext::default();
+
+        compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
+        match &cmd.data {
+            CommandData::Text(text) => {
+                assert_eq!(text.as_ref(), b"\xC2\n");
             }
             _ => panic!("Expected CommandData::Text"),
         }
@@ -3137,7 +3334,7 @@ mod tests {
         compile_text_command(&mut lines, &mut chars, &mut cmd, &mut context).unwrap();
         match &cmd.data {
             CommandData::Text(text) => {
-                assert_eq!(text.to_string(), "line1\nline2\n");
+                assert_eq!(text.as_ref(), b"line1\nline2\n");
             }
             _ => panic!("Expected CommandData::Text"),
         }
@@ -3190,5 +3387,15 @@ mod tests {
 
         let err = read_file_path(&lines, &mut chars).unwrap_err();
         assert!(err.to_string().contains("missing file path"));
+    }
+
+    #[test]
+    #[cfg(not(unix))]
+    fn test_read_file_path_rejects_invalid_characters() {
+        let lines = ScriptLineProvider::new(vec![]);
+        let mut chars = ScriptCharProvider::new(b"w bad\xFFpath");
+
+        let err = read_file_path(&lines, &mut chars).unwrap_err();
+        assert!(err.to_string().contains("invalid characters file path"));
     }
 }

--- a/src/sed/delimited_parser.rs
+++ b/src/sed/delimited_parser.rs
@@ -8,13 +8,29 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use crate::sed::command::{RE_DUP_MAX, RegexMode};
+use crate::sed::command::{CharacterMode, ParsedTransliteration, RE_DUP_MAX, RegexMode};
 use crate::sed::error_handling::compilation_error;
 use crate::sed::script_char_provider::ScriptCharProvider;
 use crate::sed::script_line_provider::ScriptLineProvider;
 
 use std::char;
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+use std::string::FromUtf8Error;
 use uucore::error::UResult;
+
+/// Construct an OS string from arbitrary bytes.
+#[cfg(unix)]
+pub fn os_string_from_bytes(bytes: Vec<u8>) -> Result<OsString, FromUtf8Error> {
+    Ok(OsString::from_vec(bytes))
+}
+
+/// Construct an OS string from UTF-8 bytes on platforms without byte-native paths.
+#[cfg(not(unix))]
+pub fn os_string_from_bytes(bytes: Vec<u8>) -> Result<OsString, FromUtf8Error> {
+    String::from_utf8(bytes).map(OsString::from)
+}
 
 /// Return true if c is a valid octal digit
 fn is_ascii_octal_digit(c: char) -> bool {
@@ -79,6 +95,30 @@ fn create_control_char(x: char) -> Option<char> {
 
     let transformed = (c as u8) ^ 0x40;
     char::from_u32(u32::from(transformed))
+}
+
+/// Append a parsed script character according to the active character mode.
+pub fn push_script_char(bytes: &mut Vec<u8>, ch: char, character_mode: CharacterMode) {
+    match character_mode {
+        CharacterMode::Byte if (ch as u32) <= 0xFF => bytes.push(ch as u8),
+        _ => {
+            let mut buf = [0u8; 4];
+            bytes.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+        }
+    }
+}
+
+/// Decode parsed script bytes as UTF-8 for character-mode parsing.
+fn parsed_bytes_to_utf8(
+    lines: &ScriptLineProvider,
+    line: &ScriptCharProvider,
+    bytes: Vec<u8>,
+    description: &str,
+) -> UResult<String> {
+    String::from_utf8(bytes).map_err(|e| {
+        compilation_error::<String>(lines, line, format!("invalid UTF-8 in {description}: {e}"))
+            .unwrap_err()
+    })
 }
 
 /// Parse a character escape valid in all contexts (RE pattern, substitution,
@@ -177,15 +217,16 @@ pub fn parse_char_escape(line: &mut ScriptCharProvider) -> Option<char> {
     }
 }
 
-/// Parse a POSIX RE character class returning it as a string.
+/// Parse a POSIX RE character class returning it as bytes.
 /// This functionality is needed to avoid terminating delimited
 /// sequences when a delimiter appears within a character class.
 /// While at it, handle escaped characters for the sake of consistency.
 fn parse_character_class(
     lines: &ScriptLineProvider,
     line: &mut ScriptCharProvider,
-) -> UResult<String> {
-    let mut result = String::new();
+    character_mode: CharacterMode,
+) -> UResult<Vec<u8>> {
+    let mut result = Vec::new();
 
     assert!(
         !line.eol() && line.current() == '[',
@@ -193,17 +234,17 @@ fn parse_character_class(
     );
 
     line.advance();
-    result.push('[');
+    result.push(b'[');
 
     // Optional negation
     if !line.eol() && line.current() == '^' {
-        result.push('^');
+        result.push(b'^');
         line.advance();
     }
 
     // Optional leading ']' inside the class
     if !line.eol() && line.current() == ']' {
-        result.push(']');
+        result.push(b']');
         line.advance();
     }
 
@@ -211,7 +252,7 @@ fn parse_character_class(
         let ch = line.current();
 
         if ch == ']' {
-            result.push(']');
+            result.push(b']');
             line.advance();
             return Ok(result);
         }
@@ -219,7 +260,7 @@ fn parse_character_class(
         if ch == '[' {
             line.advance();
             if line.eol() {
-                result.push('[');
+                result.push(b'[');
                 continue;
             }
             let marker = line.current();
@@ -227,10 +268,10 @@ fn parse_character_class(
             if marker == ':' || marker == '.' || marker == '=' {
                 line.advance();
 
-                result.push('[');
-                result.push(marker);
+                result.push(b'[');
+                result.push(marker as u8);
 
-                let mut inner = String::new();
+                let mut inner = Vec::new();
                 let mut terminated = false;
 
                 while !line.eol() {
@@ -239,16 +280,16 @@ fn parse_character_class(
                         line.advance();
                         if !line.eol() && line.current() == ']' {
                             line.advance();
-                            result.push_str(&inner);
-                            result.push(marker);
-                            result.push(']');
+                            result.extend_from_slice(&inner);
+                            result.push(marker as u8);
+                            result.push(b']');
                             terminated = true;
                             break;
                         }
                         // False alarm, just part of the inner name
-                        inner.push(marker);
+                        inner.push(marker as u8);
                     } else {
-                        inner.push(c);
+                        inner.push(line.current_byte());
                         line.advance();
                     }
                 }
@@ -264,8 +305,8 @@ fn parse_character_class(
                 continue;
             }
             // Not a POSIX construct — treat as literal
-            result.push('[');
-            result.push(marker);
+            result.push(b'[');
+            result.push(line.current_byte());
             line.advance();
             continue;
         }
@@ -277,14 +318,14 @@ fn parse_character_class(
                 break;
             }
             if let Some(decoded) = parse_char_escape(line) {
-                result.push(decoded);
+                push_script_char(&mut result, decoded, character_mode);
             } else {
-                result.push('\\');
-                result.push(line.current());
+                result.push(b'\\');
+                result.push(line.current_byte());
                 line.advance();
             }
         } else {
-            result.push(ch);
+            result.push(line.current_byte());
             line.advance();
         }
     }
@@ -317,14 +358,24 @@ pub fn parse_regex(
     lines: &ScriptLineProvider,
     line: &mut ScriptCharProvider,
     regex_mode: RegexMode,
-) -> UResult<String> {
+) -> UResult<Vec<u8>> {
+    parse_regex_for_mode(lines, line, regex_mode, CharacterMode::Utf8)
+}
+
+/// Parse a regular expression according to the current character mode.
+pub fn parse_regex_for_mode(
+    lines: &ScriptLineProvider,
+    line: &mut ScriptCharProvider,
+    regex_mode: RegexMode,
+    character_mode: CharacterMode,
+) -> UResult<Vec<u8>> {
     let delimiter = scan_delimiter(lines, line)?;
-    let mut result = String::new();
+    let mut result = Vec::new();
     while !line.eol() {
         match line.current() {
             '[' if delimiter != '[' => {
-                let cc = parse_character_class(lines, line)?;
-                result.push_str(&cc);
+                let cc = parse_character_class(lines, line, character_mode)?;
+                result.extend_from_slice(&cc);
                 continue;
             }
             '\\' => {
@@ -334,30 +385,30 @@ pub fn parse_regex(
                 }
                 if line.current() == delimiter {
                     // Push escaped delimiter
-                    result.push(line.current());
+                    result.push(line.current_byte());
                     line.advance();
                     continue;
                 }
                 if line.current() == '{' && matches!(regex_mode, RegexMode::Basic) {
                     validate_quantifier_structure(lines, line, delimiter, RegexMode::Basic)?;
                     let quantifier = validate_quantifier_numbers(lines, line)?;
-                    result.push('\\');
-                    result.push('{');
-                    result.push_str(&quantifier);
+                    result.push(b'\\');
+                    result.push(b'{');
+                    result.extend_from_slice(quantifier.as_bytes());
                     continue;
                 }
                 if line.current() == '}' {
-                    result.push('\\');
-                    result.push('}');
+                    result.push(b'\\');
+                    result.push(b'}');
                     line.advance();
                     continue;
                 }
                 if let Some(decoded) = parse_char_escape(line) {
-                    result.push(decoded);
+                    push_script_char(&mut result, decoded, character_mode);
                 } else {
                     // Pass through \<any> to RE engine for further treatment
-                    result.push('\\');
-                    result.push(line.current());
+                    result.push(b'\\');
+                    result.push(line.current_byte());
                     line.advance();
                 }
                 continue;
@@ -365,18 +416,18 @@ pub fn parse_regex(
             '{' if delimiter != '{' && matches!(regex_mode, RegexMode::Extended) => {
                 validate_quantifier_structure(lines, line, delimiter, RegexMode::Extended)?;
                 let quantifier = validate_quantifier_numbers(lines, line)?;
-                result.push('{');
-                result.push_str(&quantifier);
+                result.push(b'{');
+                result.extend_from_slice(quantifier.as_bytes());
                 continue;
             }
             '}' if delimiter != '}' => {
-                result.push('}');
+                result.push(b'}');
                 line.advance();
                 continue;
             }
 
             c if c == delimiter => return Ok(result),
-            c => result.push(c),
+            _ => result.push(line.current_byte()),
         }
         line.advance();
     }
@@ -541,9 +592,18 @@ fn validate_quantifier_numbers(
 pub fn parse_transliteration(
     lines: &ScriptLineProvider,
     line: &mut ScriptCharProvider,
-) -> UResult<String> {
+) -> UResult<Vec<u8>> {
+    parse_transliteration_bytes(lines, line, CharacterMode::Utf8)
+}
+
+/// Parse transliteration bytes according to the current character mode.
+fn parse_transliteration_bytes(
+    lines: &ScriptLineProvider,
+    line: &mut ScriptCharProvider,
+    character_mode: CharacterMode,
+) -> UResult<Vec<u8>> {
     let delimiter = scan_delimiter(lines, line)?;
-    let mut result = String::new();
+    let mut result = Vec::new();
 
     while !line.eol() {
         match line.current() {
@@ -554,31 +614,76 @@ pub fn parse_transliteration(
                 }
                 if line.current() == delimiter || line.current() == '\\' {
                     // Push only the escaped character
-                    result.push(line.current());
+                    result.push(line.current_byte());
                     line.advance();
                     continue;
                 }
                 if let Some(decoded) = parse_char_escape(line) {
-                    result.push(decoded);
+                    push_script_char(&mut result, decoded, character_mode);
                 } else {
                     // Pass through \<any> to tr for literal use
-                    result.push('\\');
-                    result.push(line.current());
+                    result.push(b'\\');
+                    result.push(line.current_byte());
                     line.advance();
                 }
                 continue;
             }
             c if c == delimiter => return Ok(result),
-            c => result.push(c),
+            _ => result.push(line.current_byte()),
         }
         line.advance();
     }
     compilation_error(lines, line, "unterminated transliteration string")
 }
 
+/// Parse a transliteration string according to the current character mode.
+pub fn parse_transliteration_for_mode(
+    lines: &ScriptLineProvider,
+    line: &mut ScriptCharProvider,
+    character_mode: CharacterMode,
+) -> UResult<ParsedTransliteration> {
+    let bytes = parse_transliteration_bytes(lines, line, character_mode)?;
+    match character_mode {
+        CharacterMode::Byte => Ok(ParsedTransliteration::Bytes(bytes)),
+        CharacterMode::Utf8 => parsed_bytes_to_utf8(lines, line, bytes, "transliteration string")
+            .map(ParsedTransliteration::Text),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStrExt;
+
+    #[test]
+    #[cfg(unix)]
+    fn test_os_string_from_bytes_preserves_non_utf8_on_unix() {
+        let os = os_string_from_bytes(b"a\xFFb".to_vec()).unwrap();
+        assert_eq!(os.as_os_str().as_bytes(), b"a\xFFb");
+    }
+
+    #[test]
+    fn test_os_string_from_bytes_accepts_utf8() {
+        let os = os_string_from_bytes("aé".as_bytes().to_vec()).unwrap();
+        assert_eq!(os, OsString::from("aé"));
+    }
+
+    #[test]
+    fn test_parsed_bytes_to_utf8_accepts_valid_utf8() {
+        let lines = ScriptLineProvider::with_active_state("test.sed", 1);
+        let line = ScriptCharProvider::new("");
+        let text = parsed_bytes_to_utf8(&lines, &line, "é".as_bytes().to_vec(), "test").unwrap();
+        assert_eq!(text, "é");
+    }
+
+    #[test]
+    fn test_parsed_bytes_to_utf8_rejects_invalid_utf8() {
+        let lines = ScriptLineProvider::with_active_state("test.sed", 1);
+        let line = ScriptCharProvider::new("");
+        let err = parsed_bytes_to_utf8(&lines, &line, b"\xE9".to_vec(), "test").unwrap_err();
+        assert!(err.to_string().contains("invalid UTF-8 in test"));
+    }
 
     fn make_providers(input: &str) -> (ScriptLineProvider, ScriptCharProvider) {
         let lines = ScriptLineProvider::new(vec![]); // Empty for tests
@@ -754,7 +859,7 @@ mod tests {
 
     #[test]
     fn test_control_escape_invalid() {
-        assert_eq!(escape_result_with_current("cé"), (Some('c'), Some('é')));
+        assert_eq!(escape_result_with_current("cé"), (Some('c'), Some('Ã')));
     }
 
     #[test]
@@ -770,6 +875,20 @@ mod tests {
     #[test]
     fn test_hex_escape_valid() {
         assert_eq!(escape_result_with_current("x41;"), (Some('A'), Some(';')));
+    }
+
+    #[test]
+    fn test_push_script_char_byte_mode_single_byte() {
+        let mut bytes = Vec::new();
+        push_script_char(&mut bytes, 'é', CharacterMode::Byte);
+        assert_eq!(bytes, b"\xE9");
+    }
+
+    #[test]
+    fn test_push_script_char_utf8_mode_encodes_utf8() {
+        let mut bytes = Vec::new();
+        push_script_char(&mut bytes, 'é', CharacterMode::Utf8);
+        assert_eq!(bytes, "é".as_bytes());
     }
 
     #[test]
@@ -818,103 +937,119 @@ mod tests {
     fn test_basic_character_class() {
         let mut line = char_provider_from("[qr]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[qr]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[qr]");
     }
 
     #[test]
     fn test_negated_class() {
         let mut line = char_provider_from("[^abc]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[^abc]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[^abc]");
     }
 
     #[test]
     fn test_leading_close_bracket() {
         let mut line = char_provider_from("[]abc]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[]abc]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[]abc]");
     }
 
     #[test]
     fn test_leading_negated_close_bracket() {
         let mut line = char_provider_from("[^]abc]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[^]abc]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[^]abc]");
     }
 
     #[test]
     fn test_escaped_character_begin() {
         let mut line = char_provider_from("[\\nabc]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[\nabc]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[\nabc]");
     }
 
     #[test]
     fn test_escaped_character_middle() {
         let mut line = char_provider_from("[a\\nbc]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[a\nbc]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[a\nbc]");
     }
 
     #[test]
     fn test_escaped_character_end() {
         let mut line = char_provider_from("[abc\\n]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[abc\n]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[abc\n]");
     }
 
     #[test]
     fn test_escaped_delimiter() {
         let mut line = char_provider_from("[a\\]bc]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[a\\]bc]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, br"[a\]bc]");
     }
 
     #[test]
     fn test_posix_class() {
         let mut line = char_provider_from("[[:digit:]]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[[:digit:]]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[[:digit:]]");
+    }
+
+    #[test]
+    fn test_colon_literal_character_class() {
+        let mut line = char_provider_from("[:]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[:]");
     }
 
     #[test]
     fn test_equivalence_class() {
         let mut line = char_provider_from("[[=a=]]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[[=a=]]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[[=a=]]");
     }
 
     #[test]
     fn test_collating_symbol() {
         let mut line = char_provider_from("[[.ch.]]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[[.ch.]]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[[.ch.]]");
     }
 
     #[test]
     fn test_unterminated_class_error() {
         let mut line = char_provider_from("[abc"); // missing closing ]
         let lines = test_lines();
-        let err = parse_character_class(&lines, &mut line);
+        let err = parse_character_class(&lines, &mut line, CharacterMode::Utf8);
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_open_bracket_at_eol_errors() {
+        let mut line = char_provider_from("[");
+        let lines = test_lines();
+        let err = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap_err();
+        assert!(err.to_string().contains("Unterminated bracket expression"));
     }
 
     #[test]
     fn test_unterminated_posix_class_error() {
         let mut line = char_provider_from("[[:digit:]");
         let lines = test_lines();
-        let err = parse_character_class(&lines, &mut line);
+        let err = parse_character_class(&lines, &mut line, CharacterMode::Utf8);
         assert!(err.is_err());
     }
 
@@ -922,7 +1057,7 @@ mod tests {
     fn test_unterminated_escape_error() {
         let mut line = char_provider_from("[abc\\"); // missing closing ]
         let lines = test_lines();
-        let err = parse_character_class(&lines, &mut line);
+        let err = parse_character_class(&lines, &mut line, CharacterMode::Utf8);
         assert!(err.is_err());
     }
 
@@ -930,8 +1065,16 @@ mod tests {
     fn test_malformed_posix_like_pattern_treated_as_literal() {
         let mut line = char_provider_from("[[x]yz]");
         let lines = test_lines();
-        let result = parse_character_class(&lines, &mut line).unwrap();
-        assert_eq!(result, "[[x]");
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[[x]");
+    }
+
+    #[test]
+    fn test_literal_open_bracket_in_character_class() {
+        let mut line = char_provider_from("[a[b]");
+        let lines = test_lines();
+        let result = parse_character_class(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(result, b"[a[b]");
     }
 
     // parse_regex
@@ -939,7 +1082,7 @@ mod tests {
     fn test_simple_regex() {
         let (lines, mut line) = make_providers("/abc/");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "abc");
+        assert_eq!(parsed, b"abc");
         assert_eq!(line.current(), '/');
     }
 
@@ -947,7 +1090,7 @@ mod tests {
     fn test_regex_with_escaped_delimiter() {
         let (lines, mut line) = make_providers("/ab\\/c/");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "ab/c");
+        assert_eq!(parsed, b"ab/c");
         assert_eq!(line.current(), '/');
     }
 
@@ -955,7 +1098,7 @@ mod tests {
     fn test_regex_with_capture() {
         let (lines, mut line) = make_providers(r"/\(.\)/c/");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, r"\(.\)");
+        assert_eq!(parsed, br"\(.\)");
         assert_eq!(line.current(), '/');
     }
 
@@ -963,7 +1106,7 @@ mod tests {
     fn test_regex_with_escape_sequence() {
         let (lines, mut line) = make_providers("/ab\\n/");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "ab\n");
+        assert_eq!(parsed, b"ab\n");
         assert_eq!(line.current(), '/');
     }
 
@@ -971,7 +1114,7 @@ mod tests {
     fn test_basic_regex_quantifier() {
         let (lines, mut line) = make_providers("/a\\{2,3\\}/p");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "a\\{2,3\\}");
+        assert_eq!(parsed, br"a\{2,3\}");
         assert_eq!(line.current(), '/');
     }
 
@@ -993,7 +1136,7 @@ mod tests {
     fn test_extended_regex_quantifier() {
         let (lines, mut line) = make_providers("/a{2,3}/p");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Extended).unwrap();
-        assert_eq!(parsed, "a{2,3}");
+        assert_eq!(parsed, b"a{2,3}");
         assert_eq!(line.current(), '/');
     }
 
@@ -1067,7 +1210,7 @@ mod tests {
     fn test_regex_with_character_class() {
         let (lines, mut line) = make_providers("/[a-z]/");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "[a-z]");
+        assert_eq!(parsed, b"[a-z]");
         assert_eq!(line.current(), '/');
     }
 
@@ -1075,7 +1218,7 @@ mod tests {
     fn test_regex_with_bracket_delimiter() {
         let (lines, mut line) = make_providers("[abc[");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "abc");
+        assert_eq!(parsed, b"abc");
         assert_eq!(line.current(), '[');
     }
 
@@ -1083,7 +1226,7 @@ mod tests {
     fn test_bracket_regex_with_bracket_delimiter() {
         let (lines, mut line) = make_providers("[a\\[0-9]bc[");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "a[0-9]bc");
+        assert_eq!(parsed, b"a[0-9]bc");
         assert_eq!(line.current(), '[');
     }
 
@@ -1091,7 +1234,7 @@ mod tests {
     fn test_regex_with_escaped_bracket_in_character_class() {
         let (lines, mut line) = make_providers("/[a\\]z]/");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "[a\\]z]");
+        assert_eq!(parsed, br"[a\]z]");
         assert_eq!(line.current(), '/');
     }
 
@@ -1099,7 +1242,7 @@ mod tests {
     fn test_regex_with_delimiter_inside_character_class() {
         let (lines, mut line) = make_providers("/[a/c]/");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "[a/c]");
+        assert_eq!(parsed, b"[a/c]");
         assert_eq!(line.current(), '/');
     }
 
@@ -1107,7 +1250,7 @@ mod tests {
     fn test_regex_with_escaped_paren_and_backslash() {
         let (lines, mut line) = make_providers("/\\(\\\\/");
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
-        assert_eq!(parsed, "\\(\\\\");
+        assert_eq!(parsed, br"\(\\");
         assert_eq!(line.current(), '/');
     }
 
@@ -1268,7 +1411,7 @@ mod tests {
     fn test_simple_transliteration() {
         let (lines, mut line) = make_providers("/abc/");
         let parsed = parse_transliteration(&lines, &mut line).unwrap();
-        assert_eq!(parsed, "abc");
+        assert_eq!(parsed, b"abc");
         assert_eq!(line.current(), '/');
     }
 
@@ -1276,7 +1419,7 @@ mod tests {
     fn test_transliteration_with_escaped_delimiter() {
         let (lines, mut line) = make_providers("/ab\\/c/");
         let parsed = parse_transliteration(&lines, &mut line).unwrap();
-        assert_eq!(parsed, "ab/c");
+        assert_eq!(parsed, b"ab/c");
         assert_eq!(line.current(), '/');
     }
 
@@ -1284,7 +1427,15 @@ mod tests {
     fn test_transliteration_with_escaped_backslash() {
         let (lines, mut line) = make_providers("/ab\\\\c/");
         let parsed = parse_transliteration(&lines, &mut line).unwrap();
-        assert_eq!(parsed, "ab\\c");
+        assert_eq!(parsed, br"ab\c");
+        assert_eq!(line.current(), '/');
+    }
+
+    #[test]
+    fn test_transliteration_backslash_character() {
+        let (lines, mut line) = make_providers("/\\\\/");
+        let parsed = parse_transliteration_bytes(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(parsed, br"\");
         assert_eq!(line.current(), '/');
     }
 
@@ -1292,7 +1443,25 @@ mod tests {
     fn test_transliteration_with_escape_sequence() {
         let (lines, mut line) = make_providers("/ab\\n/");
         let parsed = parse_transliteration(&lines, &mut line).unwrap();
-        assert_eq!(parsed, "ab\n");
+        assert_eq!(parsed, b"ab\n");
+        assert_eq!(line.current(), '/');
+    }
+
+    #[test]
+    fn test_parse_transliteration_for_mode_bytes() {
+        let (lines, mut line) = make_providers("/a\\xE9/");
+        let parsed =
+            parse_transliteration_for_mode(&lines, &mut line, CharacterMode::Byte).unwrap();
+        assert_eq!(parsed, ParsedTransliteration::Bytes(b"a\xE9".to_vec()));
+        assert_eq!(line.current(), '/');
+    }
+
+    #[test]
+    fn test_parse_transliteration_for_mode_utf8() {
+        let (lines, mut line) = make_providers("/a\\xE9/");
+        let parsed =
+            parse_transliteration_for_mode(&lines, &mut line, CharacterMode::Utf8).unwrap();
+        assert_eq!(parsed, ParsedTransliteration::Text("aé".to_string()));
         assert_eq!(line.current(), '/');
     }
 

--- a/src/sed/fast_io.rs
+++ b/src/sed/fast_io.rs
@@ -37,7 +37,6 @@ use std::str;
 use std::path::PathBuf;
 use uucore::error::UError;
 
-#[cfg(unix)]
 use uucore::error::USimpleError;
 
 #[cfg(unix)]
@@ -112,7 +111,7 @@ impl<'a> MmapLineCursor<'a> {
 /// Buffered line reader from any BufRead input.
 pub struct ReadLineCursor {
     reader: Box<dyn BufRead>,
-    buffer: String,
+    buffer: Vec<u8>,
 }
 
 impl ReadLineCursor {
@@ -121,20 +120,20 @@ impl ReadLineCursor {
         let buf = BufReader::new(r);
         Self {
             reader: Box::new(buf),
-            buffer: String::new(),
+            buffer: Vec::new(),
         }
     }
 
     /// If a line is available, return it and its \n termination.
-    fn get_line(&mut self) -> io::Result<Option<(String, bool)>> {
+    fn get_line(&mut self) -> io::Result<Option<(Vec<u8>, bool)>> {
         self.buffer.clear();
         // read_line *includes* the '\n' if present
-        let bytes_read = self.reader.read_line(&mut self.buffer)?;
+        let bytes_read = self.reader.read_until(b'\n', &mut self.buffer)?;
         if bytes_read == 0 {
             return Ok(None);
         }
         // O(1) check whether it ended in '\n'
-        let has_newline = self.buffer.ends_with('\n');
+        let has_newline = self.buffer.ends_with(b"\n");
         // strip it if you don’t want to expose it to the caller
         if has_newline {
             self.buffer.pop();
@@ -181,7 +180,7 @@ impl<'a> IOChunk<'a> {
             }
             #[cfg(unix)]
             _ => {
-                self.content = IOChunkContent::new_owned(String::new(), false);
+                self.content = IOChunkContent::new_owned(Vec::new(), false);
             }
         }
     }
@@ -210,7 +209,7 @@ impl<'a> IOChunk<'a> {
     /// Create an Owned newline-terminated IOChunk from a string.
     pub fn new_from_str(s: &str) -> Self {
         IOChunk {
-            content: IOChunkContent::new_owned(s.to_string(), true),
+            content: IOChunkContent::new_owned(s.as_bytes().to_vec(), true),
             utf8_verified: Cell::new(false),
         }
     }
@@ -218,7 +217,14 @@ impl<'a> IOChunk<'a> {
     /// Set the object's contents to the specified string.
     /// Convert it into Owned if needed.
     pub fn set_to_string(&mut self, new_content: String, add_newline: bool) {
+        self.set_to_bytes(new_content.into_bytes(), add_newline);
         self.utf8_verified.set(true);
+    }
+
+    /// Set the object's contents to the specified bytes.
+    /// Convert it into Owned if needed.
+    pub fn set_to_bytes(&mut self, new_content: Vec<u8>, add_newline: bool) {
+        self.utf8_verified.set(false);
         match &mut self.content {
             IOChunkContent::Owned {
                 content,
@@ -242,14 +248,23 @@ impl<'a> IOChunk<'a> {
             IOChunkContent::MmapInput { content, .. } => {
                 if self.utf8_verified.get() {
                     // Use cached result
+                    // SAFETY: `utf8_verified` is set only if `content`
+                    // is derived from a String or if it has been
+                    // successfully verified.
                     Ok(unsafe { self.content.as_str_unchecked() })
                 } else {
-                    let result = str::from_utf8(content);
-                    self.utf8_verified.set(true);
-                    result.map_err(|e| USimpleError::new(2, e.to_string()))
+                    match str::from_utf8(content) {
+                        Ok(s) => {
+                            self.utf8_verified.set(true);
+                            Ok(s)
+                        }
+                        Err(e) => Err(USimpleError::new(2, e.to_string())),
+                    }
                 }
             }
-            IOChunkContent::Owned { content, .. } => Ok(content),
+            IOChunkContent::Owned { content, .. } => {
+                str::from_utf8(content).map_err(|e| USimpleError::new(2, e.to_string()))
+            }
         }
     }
 
@@ -258,32 +273,28 @@ impl<'a> IOChunk<'a> {
         match &self.content {
             #[cfg(unix)]
             IOChunkContent::MmapInput { content, .. } => content,
-            IOChunkContent::Owned { content, .. } => content.as_bytes(),
+            IOChunkContent::Owned { content, .. } => content,
         }
     }
 
     /// Convert content to the Owned variant if it's not already.
-    /// Fails if the conversion to UTF-8 fails.
     pub fn ensure_owned(&mut self) -> Result<(), Box<dyn UError>> {
         match &self.content {
             IOChunkContent::Owned { .. } => Ok(()), // already owned
             #[cfg(unix)]
             IOChunkContent::MmapInput {
                 content, full_span, ..
-            } => match std::str::from_utf8(content) {
-                Ok(valid_str) => {
-                    let has_newline = full_span.last().copied() == Some(b'\n');
-                    self.content = IOChunkContent::new_owned(valid_str.to_string(), has_newline);
-                    self.utf8_verified.set(true);
-                    Ok(())
-                }
-                Err(e) => Err(USimpleError::new(2, e.to_string())),
-            },
+            } => {
+                let has_newline = full_span.last().copied() == Some(b'\n');
+                self.content = IOChunkContent::new_owned(content.to_vec(), has_newline);
+                self.utf8_verified.set(false);
+                Ok(())
+            }
         }
     }
 
     /// Return mutable access to the content and has_newline fields.
-    pub fn fields_mut(&mut self) -> Result<(&mut String, &mut bool), Box<dyn UError>> {
+    pub fn fields_mut(&mut self) -> Result<(&mut Vec<u8>, &mut bool), Box<dyn UError>> {
         self.ensure_owned()?;
 
         match &mut self.content {
@@ -312,7 +323,7 @@ enum IOChunkContent<'a> {
         full_span: &'a [u8], // Line including original newline, if any
     },
     Owned {
-        content: String,   // Line content without newline
+        content: Vec<u8>,  // Line content without newline
         has_newline: bool, // True if \n-terminated
         #[cfg(not(unix))]
         _phantom: PhantomData<&'a ()>, // Silence E0392 warning
@@ -321,7 +332,7 @@ enum IOChunkContent<'a> {
 
 impl IOChunkContent<'_> {
     /// Construct a new Owned chunk.
-    pub fn new_owned(content: String, has_newline: bool) -> Self {
+    pub fn new_owned(content: Vec<u8>, has_newline: bool) -> Self {
         #[cfg(unix)]
         return IOChunkContent::Owned {
             content,
@@ -343,7 +354,9 @@ impl IOChunkContent<'_> {
             IOChunkContent::MmapInput { content, .. } => unsafe {
                 std::str::from_utf8_unchecked(content)
             },
-            IOChunkContent::Owned { content, .. } => content,
+            IOChunkContent::Owned { content, .. } => unsafe {
+                std::str::from_utf8_unchecked(content)
+            },
         }
     }
 
@@ -627,7 +640,20 @@ impl OutputBuffer {
             s.truncate(s.len() - 1);
         }
         self.write_chunk(&IOChunk::from_content(IOChunkContent::new_owned(
-            s,
+            s.into_bytes(),
+            has_newline,
+        )))
+    }
+
+    /// Schedule the specified bytes for eventual output.
+    pub fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()> {
+        let (content, has_newline) = if bytes.ends_with(b"\n") {
+            (&bytes[..bytes.len() - 1], true)
+        } else {
+            (bytes, false)
+        };
+        self.write_chunk(&IOChunk::from_content(IOChunkContent::new_owned(
+            content.to_vec(),
             has_newline,
         )))
     }
@@ -654,9 +680,7 @@ impl OutputBuffer {
 /// Implementation of the std::io::Write trait
 impl Write for OutputBuffer {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let s =
-            std::str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        self.write_str(s)?;
+        self.write_bytes(buf)?;
         Ok(buf.len())
     }
 
@@ -741,7 +765,7 @@ impl OutputBuffer {
                 ..
             } => {
                 self.flush_mmap(WriteRange::Complete)?;
-                self.out.write_all(content.as_bytes())?;
+                self.out.write_all(content)?;
                 if *has_newline {
                     self.out.write_all(b"\n")?;
                 }
@@ -830,7 +854,7 @@ impl OutputBuffer {
                 has_newline,
                 ..
             } => {
-                self.out.write_all(content.as_bytes())?;
+                self.out.write_all(content)?;
                 if *has_newline {
                     self.out.write_all(b"\n")?;
                 }
@@ -1388,7 +1412,7 @@ mod tests {
             ..
         }) = reader.get_line()?
         {
-            assert_eq!(content, "first line");
+            assert_eq!(content, b"first line");
             assert_eq!(content.len(), 10);
             assert!(has_newline);
             assert!(!utf8_verified.get());
@@ -1407,7 +1431,7 @@ mod tests {
             ..
         }) = reader.get_line()?
         {
-            assert_eq!(content, "second line");
+            assert_eq!(content, b"second line");
             assert!(has_newline);
             assert!(!reader.last_line().unwrap());
         } else {
@@ -1492,21 +1516,21 @@ mod tests {
     // is_newline_terminated, is_empty
     #[test]
     fn test_owned_newline_terminated_non_empty() {
-        let chunk = IOChunk::from_content(IOChunkContent::new_owned("line".to_string(), true));
+        let chunk = IOChunk::from_content(IOChunkContent::new_owned(b"line".to_vec(), true));
         assert!(chunk.is_newline_terminated());
         assert!(!chunk.is_empty());
     }
 
     #[test]
     fn test_owned_newline_terminated_empty() {
-        let chunk = IOChunk::from_content(IOChunkContent::new_owned(String::new(), true));
+        let chunk = IOChunk::from_content(IOChunkContent::new_owned(Vec::new(), true));
         assert!(chunk.is_newline_terminated());
         assert!(chunk.is_empty());
     }
 
     #[test]
     fn test_owned_not_newline_terminated() {
-        let chunk = IOChunk::from_content(IOChunkContent::new_owned("line".to_string(), false));
+        let chunk = IOChunk::from_content(IOChunkContent::new_owned(b"line".to_vec(), false));
         assert!(!chunk.is_newline_terminated());
     }
 
@@ -1541,7 +1565,7 @@ mod tests {
     #[test]
     fn test_ensure_owned_on_owned() {
         let mut chunk =
-            IOChunk::from_content(IOChunkContent::new_owned("already owned".to_string(), true));
+            IOChunk::from_content(IOChunkContent::new_owned(b"already owned".to_vec(), true));
 
         let result = chunk.ensure_owned();
         assert!(result.is_ok());
@@ -1553,7 +1577,7 @@ mod tests {
                 has_newline,
                 ..
             } => {
-                assert_eq!(content, "already owned");
+                assert_eq!(content, b"already owned");
                 assert!(*has_newline);
             }
             #[cfg(unix)]
@@ -1578,7 +1602,7 @@ mod tests {
                 has_newline,
                 ..
             } => {
-                assert_eq!(content, "mmap string");
+                assert_eq!(content, b"mmap string");
                 assert!(*has_newline);
             }
             _ => panic!("Expected Owned variant after ensure_owned"),
@@ -1602,7 +1626,7 @@ mod tests {
                 has_newline,
                 ..
             } => {
-                assert_eq!(content, "no newline");
+                assert_eq!(content, b"no newline");
                 assert!(!*has_newline);
             }
             _ => panic!("Expected Owned variant after ensure_owned"),
@@ -1618,23 +1642,18 @@ mod tests {
         let mut chunk = IOChunk::from_content(new_content_mmap_input(content, full_span));
 
         let result = chunk.ensure_owned();
-        assert!(result.is_err());
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(
-            err_msg.contains("invalid utf-8"),
-            "Unexpected error message: {}",
-            err_msg
-        );
+        assert!(result.is_ok());
+        assert_eq!(chunk.as_bytes(), b"bad\xFFutf8");
+        assert!(chunk.as_str().is_err());
     }
 
     // fields_mut
     #[test]
     fn test_fields_mut_on_owned() {
-        let mut chunk =
-            IOChunk::from_content(IOChunkContent::new_owned("hello".to_string(), false));
+        let mut chunk = IOChunk::from_content(IOChunkContent::new_owned(b"hello".to_vec(), false));
 
         let (s, _) = chunk.fields_mut().unwrap();
-        s.push_str(" world");
+        s.extend_from_slice(b" world");
 
         assert_eq!(chunk.as_str().unwrap(), "hello world");
     }
@@ -1648,7 +1667,7 @@ mod tests {
 
         {
             let (s, _) = chunk.fields_mut().unwrap();
-            s.push_str("bar");
+            s.extend_from_slice(b"bar");
         }
 
         assert_eq!(chunk.as_str().unwrap(), "foobar");
@@ -1662,7 +1681,7 @@ mod tests {
         let mut chunk = IOChunk::from_content(new_content_mmap_input(content, full_span));
 
         let (s, _) = chunk.fields_mut().unwrap();
-        s.push_str(" Δεδομένα");
+        s.extend_from_slice(" Δεδομένα".as_bytes());
 
         assert_eq!(chunk.as_str().unwrap(), "Ζωντανά! Δεδομένα");
     }
@@ -1675,8 +1694,9 @@ mod tests {
         let mut chunk = IOChunk::from_content(new_content_mmap_input(content, full_span));
 
         let result = chunk.fields_mut();
-        assert!(result.is_err());
-        assert!(format!("{}", result.unwrap_err()).contains("invalid utf-8"));
+        assert!(result.is_ok());
+        assert_eq!(chunk.as_bytes(), b"abc\xFF");
+        assert!(chunk.as_str().is_err());
     }
 
     #[cfg(unix)]
@@ -1873,7 +1893,7 @@ mod tests {
         IOChunk {
             utf8_verified: Cell::new(true),
             content: IOChunkContent::Owned {
-                content: s.to_string(),
+                content: s.as_bytes().to_vec(),
                 has_newline: has_nl,
                 #[cfg(not(unix))]
                 _phantom: std::marker::PhantomData,

--- a/src/sed/fast_regex.rs
+++ b/src/sed/fast_regex.rs
@@ -15,25 +15,38 @@ use fancy_regex::{
     CaptureMatches as FancyCaptureMatches, Captures as FancyCaptures, Regex as FancyRegex,
 };
 use memchr::memmem;
-use regex::Regex as RustRegex;
 use regex::bytes::{
     CaptureMatches as ByteCaptureMatches, Captures as ByteCaptures, Regex as ByteRegex,
 };
-use std::error::Error;
 use std::sync::LazyLock;
 use uucore::error::{UResult, USimpleError};
 
+use crate::sed::command::CharacterMode;
 use crate::sed::fast_io::IOChunk;
 
+/// Convert raw pattern bytes into a valid String pattern for regex::bytes.
+fn byte_regex_pattern(pattern: &[u8]) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    for &byte in pattern {
+        if byte > 0x7F {
+            // This might result in an invalid Unicode character
+            // so encode it as a hex escape.
+            out.push_str(&format!(r"\x{byte:02X}"));
+        } else {
+            out.push(byte as char);
+        }
+    }
+    out
+}
+
 /// REs requiring the fancy_regex capabilities rather than the
-/// faster regex::bytes engine
+/// faster regex::bytes engine.
 // False positives only result in a small performance pessimization,
 // so this is just a maximally sensitive, good-enough approximation.
 // For example, r"\\1" and r"[\1]" will match, whereas only a number
 // after an odd number of backslashes and outside a character class
 // should match.
-static NEEDS_FANCY_RE: LazyLock<RustRegex> =
-    LazyLock::new(|| regex::Regex::new(r"\\[1-9]").unwrap());
+static NEEDS_FANCY_RE: LazyLock<ByteRegex> = LazyLock::new(|| ByteRegex::new(r"\\[1-9]").unwrap());
 
 /// All characters signifying that the match must be handled by an RE
 /// rather than by plain string pattern matching.
@@ -42,8 +55,8 @@ static NEEDS_FANCY_RE: LazyLock<RustRegex> =
 // matching, because Regex always constructs an automaton and needs
 // to handle state transitions, whereas plain string matching can
 // use tailored CPU string or vectored instructions.
-static NEEDS_RE: LazyLock<RustRegex> = LazyLock::new(|| {
-    regex::Regex::new(
+pub(crate) static NEEDS_RE: LazyLock<ByteRegex> = LazyLock::new(|| {
+    ByteRegex::new(
         r"(?x) # Turn on verbose mode
           ( ^                   # Non-escaped: i.e. at BOL
              | ^[^\\]            # or after a BOL non \
@@ -82,8 +95,8 @@ pub struct LiteralMatcher {
 
 impl LiteralMatcher {
     /// Construct a new matcher based on a needle possible with anchors.
-    pub fn new(needle: &str) -> Self {
-        let needle_bytes = needle.as_bytes();
+    pub fn new(needle: impl AsRef<[u8]>) -> Self {
+        let needle_bytes = needle.as_ref();
         if needle_bytes[0] == b'^' && needle_bytes[needle_bytes.len() - 1] == b'$' {
             LiteralMatcher {
                 match_type: AnchoredMatch::Both,
@@ -144,12 +157,10 @@ impl LiteralMatcher {
     }
 
     /// Return the position and contents of the matched needle.
-    pub fn find<'t>(&self, haystack: &'t [u8]) -> Option<(usize, usize, &'t str)> {
-        self.anchored_find(haystack).and_then(|start| {
+    pub fn find<'t>(&self, haystack: &'t [u8]) -> Option<(usize, usize, &'t [u8])> {
+        self.anchored_find(haystack).map(|start| {
             let end = start + self.needle.len();
-            std::str::from_utf8(&haystack[start..end])
-                .ok()
-                .map(|s| (start, end, s))
+            (start, end, &haystack[start..end])
         })
     }
 
@@ -157,7 +168,7 @@ impl LiteralMatcher {
     pub fn iter<'t>(
         &'t self,
         haystack: &'t [u8],
-    ) -> Box<dyn Iterator<Item = (usize, usize, &'t str)> + 't> {
+    ) -> Box<dyn Iterator<Item = (usize, usize, &'t [u8])> + 't> {
         let needle = &self.needle;
         let nlen = needle.len();
 
@@ -168,33 +179,30 @@ impl LiteralMatcher {
             }
             AnchoredMatch::Free => {
                 // Multiple potential matches
-                Box::new(
-                    memmem::find_iter(haystack, needle).filter_map(move |start| {
-                        let end = start + nlen;
-                        std::str::from_utf8(&haystack[start..end])
-                            .ok()
-                            .map(|s| (start, end, s))
-                    }),
-                )
+                Box::new(memmem::find_iter(haystack, needle).map(move |start| {
+                    let end = start + nlen;
+                    (start, end, &haystack[start..end])
+                }))
             }
         }
     }
 }
 
 /// Return the passed pattern without any backslash escapes.
-pub fn remove_escapes(pattern: &str) -> String {
-    let mut chars = pattern.chars().peekable();
-    let mut result = String::with_capacity(pattern.len());
+pub fn remove_escapes(pattern: &[u8]) -> Vec<u8> {
+    let mut result = Vec::with_capacity(pattern.len());
+    let mut pos = 0;
 
-    while let Some(c) = chars.next() {
-        if c == '\\' {
-            // Look ahead and consume the next character if present
-            if let Some(&next) = chars.peek() {
+    while pos < pattern.len() {
+        let byte = pattern[pos];
+        pos += 1;
+        if byte == b'\\' {
+            if let Some(&next) = pattern.get(pos) {
                 result.push(next);
-                chars.next(); // consume the peeked char
+                pos += 1;
             }
         } else {
-            result.push(c);
+            result.push(byte);
         }
     }
 
@@ -234,13 +242,42 @@ pub fn ensure_dotall(pattern: &str) -> String {
 
 impl Regex {
     /// Construct the most efficient RE-like matching engine possible.
-    pub fn new(pattern: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn new(pattern: impl AsRef<[u8]>, character_mode: CharacterMode) -> UResult<Self> {
+        let pattern = pattern.as_ref();
         if NEEDS_FANCY_RE.is_match(pattern) {
-            Ok(Self::Fancy(FancyRegex::new(&ensure_dotall(pattern))?))
+            if character_mode == CharacterMode::Byte {
+                return Err(USimpleError::new(
+                    2,
+                    "back-references are not supported in byte mode",
+                ));
+            }
+            let pattern =
+                std::str::from_utf8(pattern).map_err(|e| USimpleError::new(2, e.to_string()))?;
+            let pattern = &ensure_dotall(pattern);
+            Ok(Self::Fancy(
+                FancyRegex::new(pattern).map_err(|e| USimpleError::new(2, e.to_string()))?,
+            ))
         } else if NEEDS_RE.is_match(pattern) {
-            Ok(Self::Byte(ByteRegex::new(&ensure_dotall(pattern))?))
+            if character_mode == CharacterMode::Byte {
+                let pattern = byte_regex_pattern(pattern);
+                let pattern = &ensure_dotall(&pattern);
+                Ok(Self::Byte(
+                    regex::bytes::RegexBuilder::new(pattern)
+                        .unicode(false)
+                        .build()
+                        .map_err(|e| USimpleError::new(2, e.to_string()))?,
+                ))
+            } else {
+                let pattern = std::str::from_utf8(pattern)
+                    .map_err(|e| USimpleError::new(2, e.to_string()))?;
+                let pattern = &ensure_dotall(pattern);
+                Ok(Self::Byte(
+                    ByteRegex::new(pattern).map_err(|e| USimpleError::new(2, e.to_string()))?,
+                ))
+            }
         } else {
-            Ok(Self::Literal(LiteralMatcher::new(&remove_escapes(pattern))))
+            let pattern = remove_escapes(pattern);
+            Ok(Self::Literal(LiteralMatcher::new(pattern)))
         }
     }
 
@@ -263,7 +300,9 @@ impl Regex {
             Regex::Literal(m) => {
                 let haystack = chunk.as_bytes();
                 Ok(CaptureMatches::Literal(Box::new(m.iter(haystack).map(
-                    |(start, end, text)| Ok(Captures::Literal(Match { start, end, text })),
+                    |(start, end, bytes)| {
+                        Ok(Captures::Literal(Match::from_bytes(start, end, bytes)))
+                    },
                 ))))
             }
 
@@ -292,7 +331,7 @@ impl Regex {
                 let haystack = chunk.as_bytes();
                 match m.find(haystack) {
                     Some((start, end, text)) => {
-                        Ok(Some(Captures::Literal(Match { start, end, text })))
+                        Ok(Some(Captures::Literal(Match::from_bytes(start, end, text))))
                     }
                     None => Ok(None),
                 }
@@ -320,7 +359,7 @@ impl Regex {
             Regex::Literal(m) => {
                 let haystack = chunk.as_bytes();
                 match m.find(haystack) {
-                    Some((start, end, text)) => Ok(Some(Match { start, end, text })),
+                    Some((start, end, bytes)) => Ok(Some(Match::from_bytes(start, end, bytes))),
                     None => Ok(None),
                 }
             }
@@ -328,14 +367,11 @@ impl Regex {
             Regex::Byte(re) => {
                 let haystack = chunk.as_bytes();
                 if let Some(m) = re.find(haystack) {
-                    // Attempt UTF-8 decode for the match region only
-                    let text = std::str::from_utf8(&haystack[m.start()..m.end()])
-                        .map_err(|e| USimpleError::new(2, e.to_string()))?;
-                    Ok(Some(Match {
-                        start: m.start(),
-                        end: m.end(),
-                        text,
-                    }))
+                    Ok(Some(Match::from_bytes(
+                        m.start(),
+                        m.end(),
+                        &haystack[m.start()..m.end()],
+                    )))
                 } else {
                     Ok(None)
                 }
@@ -344,11 +380,7 @@ impl Regex {
             Regex::Fancy(re) => {
                 let text = chunk.as_str()?;
                 match re.find(text) {
-                    Ok(Some(m)) => Ok(Some(Match {
-                        start: m.start(),
-                        end: m.end(),
-                        text: m.as_str(),
-                    })),
+                    Ok(Some(m)) => Ok(Some(Match::from_str(m.start(), m.end(), m.as_str()))),
                     Ok(None) => Ok(None),
                     Err(e) => Err(USimpleError::new(2, e.to_string())),
                 }
@@ -386,23 +418,52 @@ impl<'t> Iterator for CaptureMatches<'t> {
 #[derive(Clone, Debug)]
 /// Result type for RE capture get(n)
 pub struct Match<'t> {
-    start: usize,  // Match start
-    end: usize,    // Match end
-    text: &'t str, // Actual match
+    start: usize,          // Match start
+    end: usize,            // Match end
+    bytes: &'t [u8],       // Actual match bytes
+    text: Option<&'t str>, // UTF-8 match text when available
 }
 
 /// Provide interface compatible with Regex::Match.
 impl<'t> Match<'t> {
+    /// Construct a match from raw bytes.
+    pub fn from_bytes(start: usize, end: usize, bytes: &'t [u8]) -> Self {
+        Self {
+            start,
+            end,
+            bytes,
+            text: None,
+        }
+    }
+
+    /// Construct a match from UTF-8 text.
+    pub fn from_str(start: usize, end: usize, text: &'t str) -> Self {
+        Self {
+            start,
+            end,
+            bytes: text.as_bytes(),
+            text: Some(text),
+        }
+    }
+
+    /// Return the byte offset where the match begins.
     pub fn start(&self) -> usize {
         self.start
     }
 
+    /// Return the byte offset just after the match.
     pub fn end(&self) -> usize {
         self.end
     }
 
+    /// Return the match text, or an empty string when the bytes are not UTF-8.
     pub fn as_str(&self) -> &'t str {
-        self.text
+        self.text.unwrap_or_default()
+    }
+
+    /// Return the matched bytes.
+    pub fn as_bytes(&self) -> &'t [u8] {
+        self.bytes
     }
 }
 
@@ -421,20 +482,11 @@ impl<'t> Captures<'t> {
         match self {
             Captures::Literal(m) => Ok(if i == 0 { Some(m.clone()) } else { None }),
             Captures::Byte(caps) => match caps.get(i) {
-                Some(m) => Ok(Some(Match {
-                    start: m.start(),
-                    end: m.end(),
-                    text: std::str::from_utf8(m.as_bytes())
-                        .map_err(|e| USimpleError::new(1, e.to_string()))?,
-                })),
+                Some(m) => Ok(Some(Match::from_bytes(m.start(), m.end(), m.as_bytes()))),
                 None => Ok(None),
             },
             Captures::Fancy(caps) => match caps.get(i) {
-                Some(m) => Ok(Some(Match {
-                    start: m.start(),
-                    end: m.end(),
-                    text: m.as_str(),
-                })),
+                Some(m) => Ok(Some(Match::from_str(m.start(), m.end(), m.as_str()))),
                 None => Ok(None),
             },
         }
@@ -473,7 +525,7 @@ mod tests {
 
         for pat in &should_match {
             assert!(
-                NEEDS_FANCY_RE.is_match(pat),
+                NEEDS_FANCY_RE.is_match(pat.as_bytes()),
                 "Expected NEEDS_FANCY_RE to match: {pat:?}"
             );
         }
@@ -492,7 +544,7 @@ mod tests {
 
         for pat in &should_not_match {
             assert!(
-                !NEEDS_FANCY_RE.is_match(pat),
+                !NEEDS_FANCY_RE.is_match(pat.as_bytes()),
                 "Expected NEEDS_FANCY_RE to NOT match: {pat:?}"
             );
         }
@@ -518,7 +570,7 @@ mod tests {
 
         for pat in &should_match {
             assert!(
-                NEEDS_RE.is_match(pat),
+                NEEDS_RE.is_match(pat.as_bytes()),
                 "Expected NEEDS_RE to match: {pat:?}"
             );
         }
@@ -538,38 +590,110 @@ mod tests {
 
         for pat in &should_not_match {
             assert!(
-                !NEEDS_RE.is_match(pat),
+                !NEEDS_RE.is_match(pat.as_bytes()),
                 "Expected NEEDS_RE to NOT match: {pat:?}"
             );
         }
+
+        assert!(!NEEDS_RE.is_match(b"\xC2\xE7\xCF\xC2"));
     }
 
     // Regex::new
     #[test]
     fn assert_byte_selection() {
-        let re = Regex::new(r"x*").unwrap();
+        let re = Regex::new(r"x*", CharacterMode::Utf8).unwrap();
         assert!(matches!(re, Regex::Byte(_)));
     }
 
     #[test]
+    fn assert_byte_regex_builder_path_matches_non_utf8_bytes() {
+        let re = Regex::new(b"ab.", CharacterMode::Byte).unwrap();
+        assert!(matches!(re, Regex::Byte(_)));
+
+        let mut chunk = IOChunk::new_from_str("");
+        chunk.set_to_bytes(b"ab\xE9".to_vec(), true);
+        assert!(re.is_match(&mut chunk).unwrap());
+    }
+
+    #[test]
     fn assert_fancy() {
-        let re = Regex::new(r"(.)\1").unwrap();
+        let re = Regex::new(r"(.)\1", CharacterMode::Utf8).unwrap();
         assert!(matches!(re, Regex::Fancy(_)));
     }
 
     #[test]
+    fn rejects_fancy_in_byte_mode() {
+        let err = Regex::new(r"(.)\1", CharacterMode::Byte)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("back-references are not supported in byte mode"));
+    }
+
+    #[test]
     fn assert_literal() {
-        let re = Regex::new(r"x\.").unwrap();
+        let re = Regex::new(r"x\.", CharacterMode::Utf8).unwrap();
         assert!(matches!(re, Regex::Literal(_)));
     }
 
     #[test]
     fn handles_invalid_regex_gracefully() {
-        let err = Regex::new("(").unwrap_err().to_string();
+        let err = Regex::new("(", CharacterMode::Utf8)
+            .unwrap_err()
+            .to_string();
         assert!(
             err.contains("unclosed group") || err.contains("error parsing"),
             "Unexpected error: {err:?}"
         );
+    }
+
+    #[test]
+    fn test_byte_regex_pattern_leaves_ascii() {
+        assert_eq!(byte_regex_pattern(br"a.\d"), r"a.\d");
+    }
+
+    #[test]
+    fn test_byte_regex_pattern_escapes_non_ascii_bytes() {
+        assert_eq!(byte_regex_pattern(b"a\x80\xFF"), r"a\x80\xFF");
+    }
+
+    #[test]
+    fn test_match_from_bytes_does_not_construct_text() {
+        let m = Match::from_bytes(0, 3, b"abc");
+        assert_eq!(m.as_bytes(), b"abc");
+        assert_eq!(m.as_str(), "");
+    }
+
+    #[test]
+    fn test_regex_captures_iter_returns_byte_captures() {
+        let re = Regex::new(r"([ab])", CharacterMode::Utf8).unwrap();
+        let chunk = IOChunk::new_from_str("aba");
+        let groups: Vec<Vec<u8>> = re
+            .captures_iter(&chunk)
+            .unwrap()
+            .map(|caps| {
+                caps.unwrap()
+                    .get(1)
+                    .unwrap()
+                    .expect("group 1")
+                    .as_bytes()
+                    .to_vec()
+            })
+            .collect();
+
+        assert_eq!(groups, [b"a".to_vec(), b"b".to_vec(), b"a".to_vec()]);
+    }
+
+    #[test]
+    fn test_regex_find_returns_byte_match() {
+        let re = Regex::new(b"ab.", CharacterMode::Byte).unwrap();
+        let mut chunk = IOChunk::new_from_str("");
+        chunk.set_to_bytes(b"0ab\xE91".to_vec(), true);
+        let m = re.find(&chunk).unwrap().expect("match");
+
+        assert_eq!(m.start(), 1);
+        assert_eq!(m.end(), 4);
+        assert_eq!(m.as_bytes(), b"ab\xE9");
+        assert_eq!(m.as_str(), "");
     }
 
     // remove_escapes
@@ -577,12 +701,15 @@ mod tests {
     fn test_remove_escapes() {
         use super::remove_escapes;
 
-        assert_eq!(remove_escapes("abc"), "abc");
-        assert_eq!(remove_escapes(r"a\.c"), "a.c");
-        assert_eq!(remove_escapes(r"\\d"), r"\d");
-        assert_eq!(remove_escapes(r"\.\*\+\?"), ".*+?");
-        assert_eq!(remove_escapes(r"escaped\\backslash"), r"escaped\backslash");
-        assert_eq!(remove_escapes(r"trailing\\"), r"trailing\");
+        assert_eq!(remove_escapes(b"abc"), b"abc");
+        assert_eq!(remove_escapes(br"a\.c"), b"a.c");
+        assert_eq!(remove_escapes(br"\\d"), br"\d");
+        assert_eq!(remove_escapes(br"\.\*\+\?"), b".*+?");
+        assert_eq!(
+            remove_escapes(br"escaped\\backslash"),
+            br"escaped\backslash"
+        );
+        assert_eq!(remove_escapes(br"trailing\\"), br"trailing\");
     }
 
     // LiteralMatcher
@@ -625,7 +752,7 @@ mod tests {
         let haystack = "contains ✓ unicode".as_bytes();
         assert!(matcher.is_match(haystack));
         let found = matcher.find(haystack).unwrap();
-        assert_eq!(found.2, "✓");
+        assert_eq!(found.2, "✓".as_bytes());
     }
 
     #[test]
@@ -636,7 +763,7 @@ mod tests {
         assert!(result.is_some());
         let (start, end, text) = result.unwrap();
         assert_eq!((start, end), (3, 6));
-        assert_eq!(text, "abc");
+        assert_eq!(text, b"abc");
     }
 
     #[test]
@@ -647,7 +774,7 @@ mod tests {
         assert!(result.is_some());
         let (start, end, text) = result.unwrap();
         assert_eq!((start, end), (3, 6));
-        assert_eq!(text, "abc");
+        assert_eq!(text, b"abc");
     }
 
     #[test]
@@ -658,7 +785,10 @@ mod tests {
         assert_eq!(matches.len(), 3);
 
         let strings: Vec<_> = matches.iter().map(|(_, _, s)| *s).collect();
-        assert_eq!(strings, ["test", "test", "test"]);
+        assert_eq!(
+            strings,
+            [b"test".as_slice(), b"test".as_slice(), b"test".as_slice()]
+        );
     }
 
     #[test]
@@ -669,7 +799,7 @@ mod tests {
         assert_eq!(matches.len(), 1);
 
         let strings: Vec<_> = matches.iter().map(|(_, _, s)| *s).collect();
-        assert_eq!(strings, ["test"]);
+        assert_eq!(strings, [b"test".as_slice()]);
     }
 
     #[test]
@@ -680,7 +810,7 @@ mod tests {
         assert_eq!(matches.len(), 1);
 
         let strings: Vec<_> = matches.iter().map(|(_, _, s)| *s).collect();
-        assert_eq!(strings, ["test"]);
+        assert_eq!(strings, [b"test".as_slice()]);
     }
 
     #[test]

--- a/src/sed/mod.rs
+++ b/src/sed/mod.rs
@@ -20,14 +20,15 @@ pub mod processor;
 pub mod script_char_provider;
 pub mod script_line_provider;
 
-use crate::sed::command::{ProcessingContext, StringSpace};
+use crate::sed::command::{ByteSpace, CharacterMode, ProcessingContext};
 use crate::sed::compiler::compile;
 use crate::sed::processor::process_all_files;
 use crate::sed::script_line_provider::ScriptValue;
 use clap::{Arg, ArgMatches, Command, arg, crate_version};
 use std::collections::HashMap;
+use std::env;
 use std::path::PathBuf;
-use uucore::error::{UResult, UUsageError};
+use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::format_usage;
 
 const ABOUT: &str = "Stream editor for filtering and transforming text";
@@ -46,7 +47,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let (scripts, files) = get_scripts_files(&matches)?;
-    let mut context = build_context(&matches);
+    let mut context = build_context(&matches)?;
 
     let executable = compile(scripts, &mut context)?;
     process_all_files(executable, files, &mut context)?;
@@ -192,9 +193,40 @@ fn get_scripts_files(matches: &ArgMatches) -> UResult<(Vec<ScriptValue>, Vec<Pat
     Ok((scripts, files))
 }
 
-// Parse CLI flag arguments and return a ProcessingContext struct based on them
-fn build_context(matches: &ArgMatches) -> ProcessingContext {
-    ProcessingContext {
+/// Return the character interpretation mode implied by the process locale.
+///
+/// The mode is determined from the first non-empty of LC_ALL, LC_CTYPE, and
+/// LANG. The C and POSIX locales select byte mode. UTF-8 locales (including
+/// C.UTF-8) select UTF-8 mode. All other locales result in an error.
+pub fn character_mode_for_locale(locale: &str) -> UResult<CharacterMode> {
+    if locale == "C" || locale == "POSIX" {
+        Ok(CharacterMode::Byte)
+    } else if locale.eq_ignore_ascii_case("C.UTF-8")
+        || locale.to_ascii_lowercase().ends_with(".utf-8")
+        || locale.to_ascii_lowercase().ends_with(".utf8")
+    {
+        Ok(CharacterMode::Utf8)
+    } else {
+        Err(USimpleError::new(
+            1,
+            format!("unsupported locale: {locale}"),
+        ))
+    }
+}
+
+/// Return a ProcessingContext based on parsed CLI flags and environment.
+fn build_context(matches: &ArgMatches) -> UResult<ProcessingContext> {
+    let locale = ["LC_ALL", "LC_CTYPE", "LANG"]
+        .into_iter()
+        .find_map(|name| {
+            let value = env::var(name).ok()?;
+            (!value.is_empty()).then_some(value)
+        })
+        // Same default as GNU sed
+        .unwrap_or_else(|| "C".to_string());
+
+    Ok(ProcessingContext {
+        // CLI arguments
         all_output_files: matches.get_flag("all-output-files"),
         debug: matches.get_flag("debug"),
         regex_extended: matches.get_flag("regexp-extended"),
@@ -211,6 +243,9 @@ fn build_context(matches: &ArgMatches) -> ProcessingContext {
         unbuffered: matches.get_flag("unbuffered"),
         null_data: matches.get_flag("null-data"),
 
+        // Environment
+        character_mode: character_mode_for_locale(&locale)?,
+
         // Other context
         input_name: "<stdin>".to_string(),
         line_number: 0,
@@ -220,8 +255,8 @@ fn build_context(matches: &ArgMatches) -> ProcessingContext {
         stop_processing: false,
         saved_regex: None,
         input_action: None,
-        hold: StringSpace {
-            content: String::new(),
+        hold: ByteSpace {
+            content: Vec::new(),
             has_newline: true,
         },
         parsed_block_nesting: 0,
@@ -229,7 +264,7 @@ fn build_context(matches: &ArgMatches) -> ProcessingContext {
         range_commands: Vec::new(),
         substitution_made: false,
         append_elements: Vec::new(),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -338,7 +373,7 @@ mod tests {
     #[test]
     fn test_defaults() {
         let matches = test_matches(&[]);
-        let ctx = build_context(&matches);
+        let ctx = build_context(&matches).unwrap();
 
         assert!(!ctx.all_output_files);
         assert!(!ctx.debug);
@@ -373,7 +408,7 @@ mod tests {
             "-z",
         ]);
 
-        let ctx = build_context(&matches);
+        let ctx = build_context(&matches).unwrap();
 
         assert!(ctx.all_output_files);
         assert!(ctx.debug);
@@ -393,7 +428,7 @@ mod tests {
     #[test]
     fn test_multiple_same_arguments() {
         let matches = test_matches(&["-E", "-r"]);
-        let ctx = build_context(&matches);
+        let ctx = build_context(&matches).unwrap();
 
         assert!(ctx.regex_extended);
     }
@@ -401,7 +436,7 @@ mod tests {
     #[test]
     fn test_in_place_with_suffix() {
         let matches = test_matches(&["-i", ".bak"]);
-        let ctx = build_context(&matches);
+        let ctx = build_context(&matches).unwrap();
 
         assert!(ctx.in_place);
         assert_eq!(ctx.in_place_suffix, Some(".bak".to_string()));
@@ -412,10 +447,59 @@ mod tests {
         let matches_default = test_matches(&[]);
         let matches_custom = test_matches(&["-l", "120"]);
 
-        let ctx_default = build_context(&matches_default);
-        let ctx_custom = build_context(&matches_custom);
+        let ctx_default = build_context(&matches_default).unwrap();
+        let ctx_custom = build_context(&matches_custom).unwrap();
 
         assert_eq!(ctx_default.length, 70);
         assert_eq!(ctx_custom.length, 120);
+    }
+
+    #[test]
+    fn c_locale_selects_byte_mode() {
+        assert_eq!(character_mode_for_locale("C").unwrap(), CharacterMode::Byte);
+    }
+
+    #[test]
+    fn posix_locale_selects_byte_mode() {
+        assert_eq!(
+            character_mode_for_locale("POSIX").unwrap(),
+            CharacterMode::Byte
+        );
+    }
+
+    #[test]
+    fn c_utf8_locale_selects_utf8_mode() {
+        assert_eq!(
+            character_mode_for_locale("C.UTF-8").unwrap(),
+            CharacterMode::Utf8
+        );
+    }
+
+    #[test]
+    fn dot_utf8_locale_selects_utf8_mode() {
+        assert_eq!(
+            character_mode_for_locale("en_US.UTF-8").unwrap(),
+            CharacterMode::Utf8
+        );
+    }
+
+    #[test]
+    fn dot_utf8_locale_is_case_insensitive() {
+        assert_eq!(
+            character_mode_for_locale("el_GR.utf8").unwrap(),
+            CharacterMode::Utf8
+        );
+    }
+
+    #[test]
+    fn unsupported_locale_reports_locale_name() {
+        let err = character_mode_for_locale("el_GR.ISO-8859-7").unwrap_err();
+
+        assert_eq!(err.code(), 1);
+        assert!(
+            err.to_string()
+                .contains("unsupported locale: el_GR.ISO-8859-7"),
+            "{err}"
+        );
     }
 }

--- a/src/sed/named_writer.rs
+++ b/src/sed/named_writer.rs
@@ -57,13 +57,21 @@ impl NamedWriter {
 
     /// Write a line to the file with a newline, returning descriptive errors.
     pub fn write_line(&mut self, line: &str) -> UResult<()> {
-        writeln!(self.writer, "{line}").map_err(|e| {
-            runtime_error::<()>(
-                &self.location,
-                format!("writing to file {}: {e}", self.path.quote()),
-            )
-            .unwrap_err()
-        })
+        self.write_line_bytes(line.as_bytes())
+    }
+
+    /// Write bytes to the file with a newline, returning descriptive errors.
+    pub fn write_line_bytes(&mut self, line: &[u8]) -> UResult<()> {
+        self.writer
+            .write_all(line)
+            .and_then(|()| self.writer.write_all(b"\n"))
+            .map_err(|e| {
+                runtime_error::<()>(
+                    &self.location,
+                    format!("writing to file {}: {e}", self.path.quote()),
+                )
+                .unwrap_err()
+            })
     }
 
     /// Flush the writer, returning a descriptive error.
@@ -87,4 +95,23 @@ pub fn flush_all() -> UResult<()> {
 
         Ok(())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_write_line_bytes_appends_newline() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        let writer = NamedWriter::new(path.clone(), ScriptLocation::default()).unwrap();
+
+        writer.borrow_mut().write_line_bytes(b"a\xE9").unwrap();
+        writer.borrow_mut().flush().unwrap();
+
+        assert_eq!(fs::read(path).unwrap(), b"a\xE9\n");
+    }
 }

--- a/src/sed/processor.rs
+++ b/src/sed/processor.rs
@@ -9,16 +9,20 @@
 // file that was distributed with this source code.
 
 use crate::sed::command::{
-    Address, AppendElement, Command, CommandData, InputAction, ProcessingContext, Transliteration,
+    Address, AppendElement, CharacterMode, Command, CommandData, InputAction, ProcessingContext,
+    Transliteration,
 };
+use crate::sed::delimited_parser::os_string_from_bytes;
 use crate::sed::error_handling::{ScriptLocation, input_runtime_error};
 use crate::sed::fast_io::{IOChunk, LineReader, OutputBuffer};
 use crate::sed::fast_regex::Regex;
 use crate::sed::in_place::InPlace;
 use crate::sed::named_writer;
 
+use memchr::memchr;
 use std::borrow::Cow;
 use std::cell::RefCell;
+use std::ffi::OsStr;
 use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -196,14 +200,14 @@ fn re_or_saved_re<'a>(
 }
 
 #[cfg(unix)]
-fn shell_command(cmd: &str) -> std::process::Command {
+fn shell_command(cmd: &OsStr) -> std::process::Command {
     let mut c = std::process::Command::new("/bin/sh");
     c.arg("-c").arg(cmd);
     c
 }
 
 #[cfg(windows)]
-fn shell_command(cmd: &str) -> std::process::Command {
+fn shell_command(cmd: &OsStr) -> std::process::Command {
     let mut c = std::process::Command::new("cmd.exe");
     c.arg("/C").arg(cmd);
     c
@@ -211,7 +215,7 @@ fn shell_command(cmd: &str) -> std::process::Command {
 
 // Fallback if the target OS is neither Windows nor UNIX-like
 #[cfg(not(any(unix, windows)))]
-fn shell_command(_cmd: &str) -> std::process::Command {
+fn shell_command(_cmd: &OsStr) -> std::process::Command {
     unimplemented!("the 'e' substitute flag requires a platform shell (/bin/sh or cmd.exe)");
 }
 
@@ -226,10 +230,9 @@ fn substitute(
 
     let mut count = 0;
     let mut last_end = 0;
-    let mut result = String::new();
+    let mut result = Vec::new();
     let mut replaced = false;
-
-    let mut text: Option<&str> = None;
+    let text = pattern.as_bytes();
 
     let regex = re_or_saved_re(sub.regex.as_ref(), context, &command.location)?;
 
@@ -242,11 +245,10 @@ fn substitute(
             match regex.find(pattern) {
                 Err(e) => Err(e),
                 Ok(Some(m)) => {
-                    text = Some(pattern.as_str()?);
-                    result.push_str(&text.unwrap()[last_end..m.start()]);
+                    result.extend_from_slice(&text[last_end..m.start()]);
 
                     let replacement = sub.replacement.apply_match(&m);
-                    result.push_str(&replacement);
+                    result.extend_from_slice(&replacement);
                     replaced = true;
                     last_end = m.end();
                     Ok(())
@@ -261,11 +263,10 @@ fn substitute(
                 Err(e) => Err(e),
                 Ok(Some(caps)) => {
                     let m = caps.get(0)?.unwrap();
-                    text = Some(pattern.as_str()?);
-                    result.push_str(&text.unwrap()[last_end..m.start()]);
+                    result.extend_from_slice(&text[last_end..m.start()]);
 
                     let replacement = sub.replacement.apply_captures(command, &caps)?;
-                    result.push_str(&replacement);
+                    result.extend_from_slice(&replacement);
                     replaced = true;
                     last_end = m.end();
                     Ok(())
@@ -288,18 +289,15 @@ fn substitute(
                     let m = caps.get(0)?.unwrap();
 
                     // Always write the unmatched text before this match.
-                    if text.is_none() {
-                        text = Some(pattern.as_str()?);
-                    }
-                    result.push_str(&text.unwrap()[last_end..m.start()]);
+                    result.extend_from_slice(&text[last_end..m.start()]);
 
                     if sub.occurrence == 0 || count == sub.occurrence {
                         let replacement = sub.replacement.apply_captures(command, &caps)?;
-                        result.push_str(&replacement);
+                        result.extend_from_slice(&replacement);
                         replaced = true;
                     } else {
                         // Not the target match — leave the match unchanged.
-                        result.push_str(m.as_str());
+                        result.extend_from_slice(m.as_bytes());
                     }
 
                     last_end = m.end();
@@ -322,14 +320,21 @@ fn substitute(
 
     // Handle substitution success.
     if replaced {
-        result.push_str(&text.unwrap()[last_end..]);
+        result.extend_from_slice(&text[last_end..]);
 
-        pattern.set_to_string(result, pattern.is_newline_terminated());
+        pattern.set_to_bytes(result, pattern.is_newline_terminated());
 
         // Execute the pattern space as a shell command if the 'e' flag is set
         if sub.execute {
-            let cmd_str = pattern.as_str()?.to_string();
-            let output_bytes = shell_command(&cmd_str).output().map_err(|e| {
+            let cmd = os_string_from_bytes(pattern.as_bytes().to_vec()).map_err(|e| {
+                input_runtime_error::<()>(
+                    &command.location,
+                    context,
+                    format!("failed to construct shell command from bytes: {e}"),
+                )
+                .unwrap_err()
+            })?;
+            let output_bytes = shell_command(&cmd).output().map_err(|e| {
                 input_runtime_error::<()>(
                     &command.location,
                     context,
@@ -337,15 +342,15 @@ fn substitute(
                 )
                 .unwrap_err()
             })?;
-            let mut shell_out = String::from_utf8_lossy(&output_bytes.stdout).into_owned();
-            if shell_out.ends_with("\r\n") {
+            let mut shell_out = output_bytes.stdout;
+            if shell_out.ends_with(b"\r\n") {
                 // On windows, both return carriage and newline characters are used
                 shell_out.truncate(shell_out.len() - 2);
-            } else if shell_out.ends_with('\n') {
+            } else if shell_out.ends_with(b"\n") {
                 // Strip the trailing newline, as GNU sed does
                 shell_out.pop();
             }
-            pattern.set_to_string(shell_out, pattern.is_newline_terminated());
+            pattern.set_to_bytes(shell_out, pattern.is_newline_terminated());
         }
 
         if sub.print_flag {
@@ -354,7 +359,7 @@ fn substitute(
 
         // Write to file if needed.
         if let Some(ref writer) = sub.write_file {
-            writer.borrow_mut().write_line(pattern.as_str()?)?;
+            writer.borrow_mut().write_line_bytes(pattern.as_bytes())?;
         }
         context.substitution_made = true;
     }
@@ -363,14 +368,46 @@ fn substitute(
 }
 
 /// Apply the specified transliteration in the provided pattern space.
-fn transliterate(pattern: &mut IOChunk, trans: &Transliteration) -> UResult<()> {
-    let text = pattern.as_str()?;
+fn transliterate(
+    pattern: &mut IOChunk,
+    trans: &Transliteration,
+    location: &ScriptLocation,
+    context: &ProcessingContext,
+) -> UResult<()> {
+    if context.character_mode == CharacterMode::Byte || trans.is_byte_identity {
+        let text = pattern.as_bytes();
+        let mut result = Vec::with_capacity(text.len());
+        let mut replaced = false;
+
+        for &byte in text {
+            let mapped = trans.lookup_byte(byte);
+            if mapped != byte {
+                replaced = true;
+            }
+            result.push(mapped);
+        }
+
+        if replaced {
+            pattern.set_to_bytes(result, pattern.is_newline_terminated());
+        }
+
+        return Ok(());
+    }
+
+    let text = pattern.as_str().map_err(|e| {
+        input_runtime_error::<()>(
+            location,
+            context,
+            format!("failed to decode pattern space as UTF-8 for transliteration: {e}"),
+        )
+        .unwrap_err()
+    })?;
     let mut result = String::with_capacity(text.len());
     let mut replaced = false;
 
     // Perform the transliteration.
     for ch in text.chars() {
-        let mapped = trans.lookup(ch);
+        let mapped = trans.lookup_char(ch);
         if mapped != ch {
             replaced = true;
         }
@@ -390,7 +427,7 @@ fn flush_appends(output: &mut OutputBuffer, context: &mut ProcessingContext) -> 
     for elem in &context.append_elements {
         match elem {
             AppendElement::Text(text) => {
-                output.write_str(&**text)?;
+                output.write_bytes(text.as_ref())?;
             }
             AppendElement::Path(path) => {
                 output.copy_file(path)?;
@@ -401,8 +438,93 @@ fn flush_appends(output: &mut OutputBuffer, context: &mut ProcessingContext) -> 
     Ok(())
 }
 
+/// Return the list command rendering for one ASCII byte.
+fn readable_ascii_byte(byte: u8) -> Cow<'static, str> {
+    match byte {
+        b'\x07' => Cow::Borrowed(r"\a"),
+        b'\x08' => Cow::Borrowed(r"\b"),
+        b'\x0b' => Cow::Borrowed(r"\v"),
+        b'\x0c' => Cow::Borrowed(r"\f"),
+        b'\\' => Cow::Borrowed(r"\\"),
+        b'\r' => Cow::Borrowed(r"\r"),
+        b'\t' => Cow::Borrowed(r"\t"),
+        b if b.is_ascii_control() => Cow::Owned(format!("\\{byte:03o}")),
+        b if b == b' ' || b.is_ascii_graphic() => Cow::Owned(char::from(byte).to_string()),
+        _ => Cow::Owned(format!("\\{byte:03o}")),
+    }
+}
+
+/// Return the list command rendering for one UTF-8 character.
+fn readable_char(ch: char) -> Cow<'static, str> {
+    if ch.is_ascii() {
+        return readable_ascii_byte(ch as u8);
+    }
+    if (ch as u32) <= 0xFFFF {
+        Cow::Owned(format!("\\u{:04X}", ch as u32))
+    } else {
+        Cow::Owned(format!("\\U{:08X}", ch as u32))
+    }
+}
+
+/// Buffered state for rendering one list command output line.
+struct ListLine {
+    buffer: String,
+    width: usize,
+    max_width: usize,
+}
+
+impl ListLine {
+    /// Create an empty list output line with the specified maximum width.
+    fn new(max_width: usize) -> Self {
+        Self {
+            buffer: String::new(),
+            width: 0,
+            max_width,
+        }
+    }
+
+    /// Write a rendered list item, folding before the item if needed.
+    fn write_item(&mut self, output: &mut OutputBuffer, out_str: &str) -> UResult<()> {
+        let out_len = out_str.len();
+        if self.width + out_len + 1 > self.max_width {
+            self.buffer.push_str("\\\n");
+            output.write_str(std::mem::take(&mut self.buffer))?;
+            self.width = 0;
+        }
+        self.buffer.push_str(out_str);
+        self.width += out_len;
+        Ok(())
+    }
+
+    /// Write the current list line with an embedded newline marker.
+    fn write_embedded_newline(&mut self, output: &mut OutputBuffer) -> UResult<()> {
+        self.buffer.push_str("$\n");
+        output.write_str(&self.buffer)?;
+        self.buffer.clear();
+        self.width = 0;
+        Ok(())
+    }
+
+    /// Finish the list line if it has buffered output.
+    fn finish(&mut self, output: &mut OutputBuffer) -> UResult<()> {
+        if !self.buffer.is_empty() {
+            self.buffer.push_str("$\n");
+            output.write_str(&self.buffer)?;
+            self.buffer.clear();
+            self.width = 0;
+        }
+        Ok(())
+    }
+}
+
 /// List the passed pattern space in unambiguous form.
-fn list(output: &mut OutputBuffer, line: &IOChunk, max_width: usize) -> UResult<()> {
+fn list(
+    output: &mut OutputBuffer,
+    line: &IOChunk,
+    max_width: usize,
+    location: &ScriptLocation,
+    context: &ProcessingContext,
+) -> UResult<()> {
     // Special case for an empty pattern space
     if line.is_empty() {
         if line.is_newline_terminated() {
@@ -411,50 +533,37 @@ fn list(output: &mut OutputBuffer, line: &IOChunk, max_width: usize) -> UResult<
         return Ok(());
     }
 
-    let line = line.as_str()?;
-    let mut buff = String::new();
-    let mut line_width = 0;
+    let mut list_line = ListLine::new(max_width);
 
-    for ch in line.chars() {
-        if ch == '\n' {
-            buff.push_str("$\n");
-            output.write_str(&buff)?;
-            line_width = 0;
-            continue;
+    if context.character_mode == CharacterMode::Byte {
+        for &byte in line.as_bytes() {
+            if byte == b'\n' {
+                list_line.write_embedded_newline(output)?;
+                continue;
+            }
+            let out_str = readable_ascii_byte(byte);
+            list_line.write_item(output, &out_str)?;
         }
-
-        let mut char_buff = [0u8; 1];
-        let out_str: Cow<str> = match ch {
-            '\x07' => Cow::Borrowed(r"\a"),
-            '\x08' => Cow::Borrowed(r"\b"),
-            '\x0b' => Cow::Borrowed(r"\v"),
-            '\x0c' => Cow::Borrowed(r"\f"),
-            '\\' => Cow::Borrowed(r"\\"),
-            '\r' => Cow::Borrowed(r"\r"),
-            '\t' => Cow::Borrowed(r"\t"),
-            c if c.is_ascii_control() => Cow::Owned(format!("\\{:03o}", ch as u8)),
-            c if c == ' ' || c.is_ascii_graphic() => Cow::Borrowed(ch.encode_utf8(&mut char_buff)),
-            c if (c as u32) <= 0xFFFF => Cow::Owned(format!("\\u{:04X}", c as u32)),
-            _ => Cow::Owned(format!("\\U{:08X}", ch as u32)),
-        };
-
-        // See if folding is required before adding out_str and terminator.
-        let out_len = out_str.len();
-        if line_width + out_len + 1 > max_width {
-            buff.push_str("\\\n");
-            output.write_str(&buff)?;
-            line_width = 0;
-            buff.clear();
+    } else {
+        let line = line.as_str().map_err(|e| {
+            input_runtime_error::<()>(
+                location,
+                context,
+                format!("failed to decode pattern space as UTF-8 for list command: {e}"),
+            )
+            .unwrap_err()
+        })?;
+        for ch in line.chars() {
+            if ch == '\n' {
+                list_line.write_embedded_newline(output)?;
+                continue;
+            }
+            let out_str = readable_char(ch);
+            list_line.write_item(output, &out_str)?;
         }
-        buff.push_str(out_str.as_ref());
-        line_width += out_len;
     }
 
-    if !buff.is_empty() {
-        buff.push_str("$\n");
-        output.write_str(buff)?;
-    }
-    Ok(())
+    list_line.finish(output)
 }
 
 /// Handle address 0 read at the beginning of each file.
@@ -504,12 +613,11 @@ fn process_file(
         let mut current: Option<Rc<RefCell<Command>>> =
             if let Some(action) = context.input_action.take() {
                 // Continue processing the `N` command.
-                let current_line = pattern.as_str()?;
                 let mut combined_lines = action.prepend;
-                combined_lines.push('\n');
-                combined_lines.push_str(current_line);
+                combined_lines.push(b'\n');
+                combined_lines.extend_from_slice(pattern.as_bytes());
 
-                pattern.set_to_string(combined_lines, pattern.is_newline_terminated());
+                pattern.set_to_bytes(combined_lines, pattern.is_newline_terminated());
                 action.next_command
             } else {
                 // Start from the script top.
@@ -560,7 +668,7 @@ fn process_file(
                     pattern.clear();
                     if command.addr2.is_none() || context.last_address || reader.last_line()? {
                         let text = extract_variant!(command, Text);
-                        output.write_str(text.as_ref())?;
+                        output.write_bytes(text.as_ref())?;
                     }
                     break;
                 }
@@ -571,7 +679,7 @@ fn process_file(
                 }
                 'D' => {
                     // Delete up to \n and start a new cycle without new input.
-                    if let Some(pos) = pattern.as_str()?.find('\n') {
+                    if let Some(pos) = memchr(b'\n', pattern.as_bytes()) {
                         let (s, _) = pattern.fields_mut()?;
                         s.drain(..=pos);
                         current.clone_from(&commands);
@@ -583,34 +691,34 @@ fn process_file(
                 }
                 'g' => {
                     // Replace pattern with the contents of the hold space.
-                    pattern.set_to_string(context.hold.content.clone(), context.hold.has_newline);
+                    pattern.set_to_bytes(context.hold.content.clone(), context.hold.has_newline);
                 }
                 'G' => {
                     // Append to pattern \n followed by hold space contents.
                     let (pat_content, pat_has_newline) = pattern.fields_mut()?;
-                    pat_content.push('\n');
-                    pat_content.push_str(&context.hold.content);
+                    pat_content.push(b'\n');
+                    pat_content.extend_from_slice(&context.hold.content);
                     *pat_has_newline = context.hold.has_newline;
                 }
                 'h' => {
                     // Replace hold with the contents of the pattern space.
-                    context.hold.content = pattern.as_str()?.to_string();
+                    context.hold.content = pattern.as_bytes().to_vec();
                     context.hold.has_newline = pattern.is_newline_terminated();
                 }
                 'H' => {
                     // Append to hold \n followed by pattern space contents.
-                    context.hold.content.push('\n');
-                    context.hold.content.push_str(pattern.as_str()?);
+                    context.hold.content.push(b'\n');
+                    context.hold.content.extend_from_slice(pattern.as_bytes());
                     context.hold.has_newline = pattern.is_newline_terminated();
                 }
                 'i' => {
                     // Write text to standard output.
                     let text = extract_variant!(command, Text);
-                    output.write_str(text.as_ref())?;
+                    output.write_bytes(text.as_ref())?;
                 }
                 'l' => {
                     let width = *extract_variant!(command, Number);
-                    list(output, &pattern, width)?;
+                    list(output, &pattern, width, &command.location, context)?;
                 }
                 'n' => {
                     break;
@@ -623,7 +731,7 @@ fn process_file(
                     // to perform when the next line is read.
                     context.input_action = Some(InputAction {
                         next_command: command.next.clone(),
-                        prepend: pattern.as_str()?.to_string(),
+                        prepend: pattern.as_bytes().to_vec(),
                     });
                     continue 'lines;
                 }
@@ -631,9 +739,9 @@ fn process_file(
                     write_chunk(output, context, &pattern)?;
                 }
                 'P' => {
-                    let line = pattern.as_str()?;
-                    if let Some(pos) = line.find('\n') {
-                        output.write_str(&line[..=pos])?;
+                    let line = pattern.as_bytes();
+                    if let Some(pos) = memchr(b'\n', line) {
+                        output.write_bytes(&line[..=pos])?;
                     } else {
                         write_chunk(output, context, &pattern)?;
                     }
@@ -678,7 +786,7 @@ fn process_file(
                 'w' => {
                     // Append the pattern space to the specified file.
                     let writer = extract_variant!(command, NamedWriter);
-                    writer.borrow_mut().write_line(pattern.as_str()?)?;
+                    writer.borrow_mut().write_line_bytes(pattern.as_bytes())?;
                 }
                 'x' => {
                     // Exchange the contents of the pattern and hold spaces.
@@ -692,7 +800,7 @@ fn process_file(
                 }
                 'y' => {
                     let trans = extract_variant!(command, Transliteration);
-                    transliterate(&mut pattern, trans)?;
+                    transliterate(&mut pattern, trans, &command.location, context)?;
                 }
                 'z' => {
                     // Clear the pattern contents, but preserve newline state
@@ -732,8 +840,8 @@ fn process_file(
         && let Some(action) = context.input_action.take()
     {
         let mut pending = action.prepend;
-        pending.push('\n');
-        output.write_str(pending)?;
+        pending.push(b'\n');
+        output.write_bytes(&pending)?;
         if context.unbuffered {
             output.flush()?;
         }
@@ -793,8 +901,8 @@ pub fn process_all_files(
             && let Some(action) = context.input_action.take()
         {
             let mut pending = action.prepend;
-            pending.push('\n');
-            output.write_str(pending)?;
+            pending.push(b'\n');
+            output.write_bytes(&pending)?;
         }
 
         in_place.end()?;
@@ -808,4 +916,91 @@ pub fn process_all_files(
     named_writer::flush_all()?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Seek, SeekFrom};
+    use tempfile::tempfile;
+
+    #[test]
+    fn test_readable_ascii_byte_named_escapes() {
+        assert_eq!(readable_ascii_byte(b'\n'), r"\012");
+        assert_eq!(readable_ascii_byte(b'\t'), r"\t");
+        assert_eq!(readable_ascii_byte(b'\\'), r"\\");
+    }
+
+    #[test]
+    fn test_readable_ascii_byte_printable_and_non_ascii() {
+        assert_eq!(readable_ascii_byte(b'A'), "A");
+        assert_eq!(readable_ascii_byte(b' '), " ");
+        assert_eq!(readable_ascii_byte(0xE9), r"\351");
+    }
+
+    #[test]
+    fn test_readable_char_ascii_delegates_to_byte() {
+        assert_eq!(readable_char('\t'), r"\t");
+        assert_eq!(readable_char('A'), "A");
+    }
+
+    #[test]
+    fn test_readable_char_unicode_escapes() {
+        assert_eq!(readable_char('κ'), r"\u03BA");
+        assert_eq!(readable_char('😀'), r"\U0001F600");
+    }
+
+    #[test]
+    fn test_write_list_item_appends_without_fold() {
+        let mut file = tempfile().unwrap();
+        let mut output = OutputBuffer::new(Box::new(file.try_clone().unwrap()));
+        let mut line = ListLine::new(10);
+        line.write_item(&mut output, "ab").unwrap();
+
+        line.write_item(&mut output, "cd").unwrap();
+        output.flush().unwrap();
+
+        assert_eq!(line.buffer, "abcd");
+        assert_eq!(line.width, 4);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let mut written = String::new();
+        file.read_to_string(&mut written).unwrap();
+        assert_eq!(written, "");
+    }
+
+    #[test]
+    fn test_write_list_item_folds_before_append() {
+        let mut file = tempfile().unwrap();
+        let mut output = OutputBuffer::new(Box::new(file.try_clone().unwrap()));
+        let mut line = ListLine::new(5);
+        line.write_item(&mut output, "abcd").unwrap();
+
+        line.write_item(&mut output, "e").unwrap();
+        output.flush().unwrap();
+
+        assert_eq!(line.buffer, "e");
+        assert_eq!(line.width, 1);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let mut written = String::new();
+        file.read_to_string(&mut written).unwrap();
+        assert_eq!(written, "abcd\\\n");
+    }
+
+    #[test]
+    fn test_list_line_finish_writes_terminator() {
+        let mut file = tempfile().unwrap();
+        let mut output = OutputBuffer::new(Box::new(file.try_clone().unwrap()));
+        let mut line = ListLine::new(10);
+        line.write_item(&mut output, "abc").unwrap();
+
+        line.finish(&mut output).unwrap();
+        output.flush().unwrap();
+
+        assert_eq!(line.buffer, "");
+        assert_eq!(line.width, 0);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let mut written = String::new();
+        file.read_to_string(&mut written).unwrap();
+        assert_eq!(written, "abc$\n");
+    }
 }

--- a/src/sed/script_char_provider.rs
+++ b/src/sed/script_char_provider.rs
@@ -1,4 +1,4 @@
-// Provide the script contents character by character
+// Provide the script contents byte by byte
 //
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Diomidis Spinellis
@@ -10,19 +10,20 @@
 
 #[derive(Debug)]
 pub struct ScriptCharProvider {
-    line: Vec<char>,
+    line: Vec<u8>,
     pos: usize,
 }
 
 impl ScriptCharProvider {
-    pub fn new(line_string: &str) -> Self {
+    /// Build from raw script bytes.
+    pub fn new(line: impl AsRef<[u8]>) -> Self {
         Self {
-            line: line_string.chars().collect(),
+            line: line.as_ref().to_vec(),
             pos: 0,
         }
     }
 
-    /// Advances to the next character, if not at end of line.
+    /// Advances to the next byte, if not at end of line.
     pub fn advance(&mut self) {
         if self.pos < self.line.len() {
             self.pos += 1;
@@ -39,8 +40,13 @@ impl ScriptCharProvider {
         self.pos = pos;
     }
 
-    /// Returns the current character. Panics if out of bounds.
+    /// Returns the current byte as a character. Panics if out of bounds.
     pub fn current(&self) -> char {
+        char::from(self.line[self.pos])
+    }
+
+    /// Returns the current script byte. Panics if out of bounds.
+    pub fn current_byte(&self) -> u8 {
         self.line[self.pos]
     }
 
@@ -51,8 +57,8 @@ impl ScriptCharProvider {
 
     /// Advances the position past any whitespace characters.
     pub fn eat_spaces(&mut self) {
-        while self.pos < self.line.len() && self.line[self.pos].is_whitespace() {
-            self.pos += 1;
+        while self.pos < self.line.len() && self.current().is_whitespace() {
+            self.advance();
         }
     }
 
@@ -138,5 +144,29 @@ mod tests {
 
         assert_eq!(chars.get_pos(), 2);
         assert_eq!(chars.current(), 'c');
+    }
+
+    #[test]
+    fn test_current_for_utf8_bytes() {
+        let mut chars = ScriptCharProvider::new("αb");
+
+        assert_eq!(chars.current(), char::from(0xCE));
+        assert_eq!(chars.current_byte(), 0xCE);
+        chars.advance();
+        assert_eq!(chars.current(), char::from(0xB1));
+        assert_eq!(chars.current_byte(), 0xB1);
+        chars.advance();
+        assert_eq!(chars.current(), 'b');
+    }
+
+    #[test]
+    fn test_current_for_invalid_utf8_byte() {
+        let mut chars = ScriptCharProvider::new(vec![0xC2, b'a']);
+
+        assert_eq!(chars.current(), char::from(0xC2));
+        assert_eq!(chars.current_byte(), 0xC2);
+        chars.advance();
+        assert_eq!(chars.current(), 'a');
+        assert_eq!(chars.current_byte(), b'a');
     }
 }

--- a/src/sed/script_line_provider.rs
+++ b/src/sed/script_line_provider.rs
@@ -69,8 +69,8 @@ impl ScriptLineProvider {
     }
 
     /// Return the next script line to process across all scripts.
-    pub fn next_line(&mut self) -> UResult<Option<String>> {
-        let mut line = String::new();
+    pub fn next_line(&mut self) -> UResult<Option<Vec<u8>>> {
+        let mut line = Vec::new();
 
         loop {
             let advance = match &mut self.state {
@@ -82,13 +82,13 @@ impl ScriptLineProvider {
                     ..
                 } => {
                     line.clear();
-                    let bytes = reader.read_line(&mut line)?;
+                    let bytes = reader.read_until(b'\n', &mut line)?;
                     if bytes == 0 {
                         Some(*index + 1) // finished reading this source
                     } else {
                         *line_number += 1;
                         // Remove trailing newline
-                        if line.ends_with('\n') {
+                        if line.ends_with(b"\n") {
                             line.pop();
                         }
                         return Ok(Some(line));
@@ -114,7 +114,7 @@ impl ScriptLineProvider {
 
         match &self.sources[next_index] {
             ScriptValue::StringVal(s) => {
-                let cursor = std::io::Cursor::new(s.clone());
+                let cursor = std::io::Cursor::new(s.as_bytes().to_vec());
                 self.state = State::Active {
                     index: next_index,
                     reader: Box::new(BufReader::new(cursor)),
@@ -199,7 +199,7 @@ mod tests {
 
         let mut lines = Vec::new();
         while let Some(line) = provider.next_line().unwrap() {
-            lines.push(line.trim_end().to_string());
+            lines.push(String::from_utf8(line).unwrap().trim_end().to_string());
         }
 
         assert_eq!(lines, vec!["line one", "line two", "line three"]);
@@ -216,7 +216,7 @@ mod tests {
 
         let mut lines = Vec::new();
         while let Some(line) = provider.next_line().unwrap() {
-            lines.push(line.trim_end().to_string());
+            lines.push(String::from_utf8(line).unwrap().trim_end().to_string());
         }
 
         assert_eq!(lines, vec!["file line 1", "file line 2"]);
@@ -241,7 +241,7 @@ mod tests {
 
         let mut lines = Vec::new();
         while let Some(line) = provider.next_line().unwrap() {
-            lines.push(line.trim_end().to_string());
+            lines.push(String::from_utf8(line).unwrap().trim_end().to_string());
         }
 
         assert_eq!(
@@ -266,7 +266,7 @@ mod tests {
         let mut provider = ScriptLineProvider::new(input);
 
         if let Some(line) = provider.next_line().unwrap() {
-            assert_eq!(line.trim(), "l1");
+            assert_eq!(String::from_utf8(line).unwrap().trim(), "l1");
             assert_eq!(provider.get_line_number(), 1);
             assert_eq!(provider.get_input_name(), "<script argument 1>");
         } else {
@@ -274,7 +274,7 @@ mod tests {
         }
 
         if let Some(line) = provider.next_line().unwrap() {
-            assert_eq!(line.trim(), "l2");
+            assert_eq!(String::from_utf8(line).unwrap().trim(), "l2");
             assert_eq!(provider.get_line_number(), 2);
             assert_eq!(provider.get_input_name(), "<script argument 1>");
         } else {
@@ -282,11 +282,22 @@ mod tests {
         }
 
         if let Some(line) = provider.next_line().unwrap() {
-            assert_eq!(line.trim(), "l3");
+            assert_eq!(String::from_utf8(line).unwrap().trim(), "l3");
             assert_eq!(provider.get_line_number(), 1);
             assert_eq!(provider.get_input_name(), "<script argument 2>");
         } else {
             panic!("Expected a line");
         }
+    }
+
+    #[test]
+    fn test_file_source_preserves_invalid_utf8_bytes() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(b"s/\xC2\xE7/X/\n").unwrap();
+
+        let input = vec![ScriptValue::PathVal(temp_file.path().to_path_buf())];
+        let mut provider = ScriptLineProvider::new(input);
+
+        assert_eq!(provider.next_line().unwrap().unwrap(), b"s/\xC2\xE7/X/");
     }
 }

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -85,7 +85,11 @@ fn test_e_script_ok() {
 
 #[test]
 fn test_f_script_ok() {
-    new_ucmd!().arg("-f").arg("script/hanoi.sed").succeeds();
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-f", "script/hanoi.sed"])
+        .succeeds()
+        .stdout_is_bytes(b"");
 }
 
 ////////////////////////////////////////////////////////////
@@ -560,13 +564,104 @@ check_output!(subst_literal_end, ["-e", r"s/2$/TWO/", LINES1]);
 check_output!(subst_literal, ["-e", r"s/_/-/", LINES1]);
 
 // Fancy matcher
-check_output!(subst_backref, ["-e", r"s/l\(.\)_\1/same-number/", LINES1]);
+/// Substitute using a backreference under an explicit UTF-8 locale.
+#[test]
+fn subst_backref() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-e", r"s/l\(.\)_\1/same-number/", LINES1])
+        .succeeds()
+        .stdout_is_fixture_bytes("output/subst_backref");
+}
 
-// Bytes matcher with Unicode
-check_output!(subst_greek, ["-e", r"s/[α-ω]/G/g", "input/unicode"]);
-check_output!(subst_any_unicode, ["-e", r"s/.$/:-)/", "input/unicode"]);
-check_output!(subst_lcase, ["-e", r"s/κ/*/gi", "input/unicode"]);
-check_output!(subst_word, ["-E", "-e", r"s/\w+/WORD/g", "input/unicode"]);
+/// Substitute a Unicode range under an explicit UTF-8 locale.
+#[test]
+fn subst_greek() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-e", r"s/[α-ω]/G/g", "input/unicode"])
+        .succeeds()
+        .stdout_is_fixture_bytes("output/subst_greek");
+}
+
+/// Substitute the final Unicode scalar under an explicit UTF-8 locale.
+#[test]
+fn subst_any_unicode() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-e", r"s/.$/:-)/", "input/unicode"])
+        .succeeds()
+        .stdout_is_fixture_bytes("output/subst_any_unicode");
+}
+
+/// Substitute case-insensitive Unicode text under an explicit UTF-8 locale.
+#[test]
+fn subst_lcase() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-e", r"s/κ/*/gi", "input/unicode"])
+        .succeeds()
+        .stdout_is_fixture_bytes("output/subst_lcase");
+}
+
+/// Substitute Unicode word matches under an explicit UTF-8 locale.
+#[test]
+fn subst_word() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-E", "-e", r"s/\w+/WORD/g", "input/unicode"])
+        .succeeds()
+        .stdout_is_fixture_bytes("output/subst_word");
+}
+
+/// Reject FancyRegex-only substitution patterns in byte mode.
+#[test]
+fn subst_backref_rejected_in_c_locale() {
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .args(&["-e", r"s/\(.\)\1/X/"])
+        .fails()
+        .stderr_contains("back-references are not supported in byte mode");
+}
+
+/// Allow substitution back-references when the locale selects UTF-8 mode.
+#[test]
+fn subst_backref_allowed_in_c_utf8_locale() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-e", r"s/\(.\)\1/X/"])
+        .pipe_in("aa\n")
+        .succeeds()
+        .stdout_is_bytes(b"X\n");
+}
+
+/// Match non-UTF-8 input bytes with byte escapes in byte mode.
+#[test]
+fn subst_byte_escape_matches_invalid_input_in_c_locale() {
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .args(&["-e", r"s/\xE9/Z/"])
+        .pipe_in(b"\xE9\n".to_vec())
+        .succeeds()
+        .stdout_is_bytes(b"Z\n");
+}
+
+/// Match raw invalid UTF-8 script bytes as literal bytes in UTF-8 mode.
+#[test]
+fn subst_raw_invalid_script_bytes_match_literal_in_c_utf8_locale() {
+    let mut script = NamedTempFile::new().expect("create temporary sed script");
+    script
+        .write_all(b"s/\xC2\xE7\xCF\xC2/\xC6\xFC\xCB\xDC/\n")
+        .expect("write temporary sed script");
+    let script_path = script.path().to_str().expect("temporary path is UTF-8");
+
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-f", script_path])
+        .pipe_in(b"\xA4\xC4 \xC2\xE7\xCF\xC2\xA4\xCE\n".to_vec())
+        .succeeds()
+        .stdout_is_bytes(b"\xA4\xC4 \xC6\xFC\xCB\xDC\xA4\xCE\n");
+}
 
 #[test]
 fn subst_write_file() -> std::io::Result<()> {
@@ -676,6 +771,55 @@ check_output!(
     ["-e", r"y10\123456789198765432\101", LINES1]
 );
 check_output!(trans_no_new_line, ["-e", r"y/l/L/", NO_NEW_LINE]);
+
+/// Transliterate non-UTF-8 input bytes using byte escapes in byte mode.
+#[test]
+fn trans_byte_escape_matches_invalid_input_in_c_locale() {
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .args(&["-e", r"y/\xE9/Z/"])
+        .pipe_in(b"\xE9\n".to_vec())
+        .succeeds()
+        .stdout_is_bytes(b"Z\n");
+}
+
+/// Transliterate UTF-8 characters as characters when the locale selects UTF-8 mode.
+#[test]
+fn trans_utf8_character_in_c_utf8_locale() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-e", r"y/κ/K/"])
+        .pipe_in("κa\n")
+        .succeeds()
+        .stdout_is_bytes(b"Ka\n");
+}
+
+/// Transliterate a decoded hex escape as UTF-8 in UTF-8 mode.
+#[test]
+fn trans_utf8_escape_in_c_utf8_locale() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-e", r"y/\xE9/Z/"])
+        .pipe_in("é\n")
+        .succeeds()
+        .stdout_is_bytes(b"Z\n");
+}
+
+/// Reject raw invalid UTF-8 transliteration script bytes in UTF-8 mode.
+#[test]
+fn trans_raw_invalid_script_byte_rejected_in_c_utf8_locale() {
+    let mut script = NamedTempFile::new().expect("create temporary sed script");
+    script
+        .write_all(b"y/\xE9/Z/")
+        .expect("write temporary sed script");
+    let script_path = script.path().to_str().expect("temporary path is UTF-8");
+
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-f", script_path])
+        .fails()
+        .stderr_contains("invalid UTF-8 in transliteration string");
+}
 
 #[test]
 fn pattern_clear_with_z_command() {
@@ -1231,7 +1375,27 @@ check_output!(number_range_out_of_bounds, ["-e", "47,60=", LINES1]);
 
 check_output!(list_ascii, ["-n", "l 60", "input/ascii"]);
 check_output!(list_empty, ["-n", "l 60", "input/empty"]);
-check_output!(list_unicode, ["l 60", "input/unicode"]);
+
+/// List Unicode input under an explicit UTF-8 locale.
+#[test]
+fn list_unicode() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["l 60", "input/unicode"])
+        .succeeds()
+        .stdout_is_fixture_bytes("output/list_unicode");
+}
+
+/// List invalid UTF-8 bytes without decoding in byte mode.
+#[test]
+fn list_invalid_utf8_byte_locale() {
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .args(&["-n", "l"])
+        .pipe_in(b"\xE9\n".to_vec())
+        .succeeds()
+        .stdout_is_bytes(b"\\351$\n");
+}
 
 ////////////////////////////////////////////////////////////
 // In-place editing
@@ -1441,8 +1605,15 @@ check_output!(math1, ["-f", "script/math.sed", "input/expression1"]);
 // Calculate π (scaled) to several decimal places
 check_output!(pi, ["-f", "script/math.sed", "input/pi"]);
 
-// Solve the Towers of Hanoi puzzle
-check_output!(hanoi, ["-f", "script/hanoi.sed", "input/hanoi"]);
+/// Solve the Towers of Hanoi puzzle under an explicit UTF-8 locale.
+#[test]
+fn hanoi() {
+    new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
+        .args(&["-f", "script/hanoi.sed", "input/hanoi"])
+        .succeeds()
+        .stdout_is_fixture_bytes("output/hanoi");
+}
 
 ////////////////////////////////////////////////////////////
 // Long-running scripts
@@ -1579,6 +1750,7 @@ fn test_step_end_non_posix() {
 #[test]
 fn test_fancy_regex_is_match_error() {
     new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
         .args(&["-E", r"/(\.+)+\1b$/p", "input/dots-4k.txt"])
         .fails()
         .code_is(2)
@@ -1588,6 +1760,7 @@ fn test_fancy_regex_is_match_error() {
 #[test]
 fn test_fancy_regex_find_error() {
     new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
         .args(&["-E", r"p;s/(\.+)+\1b$/X/", "input/dots-4k.txt"])
         .fails()
         .code_is(2)
@@ -1597,6 +1770,7 @@ fn test_fancy_regex_find_error() {
 #[test]
 fn test_fancy_regex_captures_error() {
     new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
         .args(&["-E", r"p;s/(\.+)+\1b$/\1/", "input/dots-4k.txt"])
         .fails()
         .code_is(2)
@@ -1606,6 +1780,7 @@ fn test_fancy_regex_captures_error() {
 #[test]
 fn test_fancy_regex_captures_iter_error() {
     new_ucmd!()
+        .env("LC_ALL", "C.UTF-8")
         .args(&["-E", r"p;s/(\.+)+\1b$/\1/3", "input/dots-4k.txt"])
         .fails()
         .code_is(2)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,9 @@ fn init() {
         std::env::remove_var("UUTESTS_UTIL_NAME");
         std::env::set_var("UUTESTS_UTIL_NAME", "");
         std::env::set_var("UUTILS_MULTICALL", "0");
+        // Keep fixture-based integration tests in UTF-8 mode; individual
+        // locale tests override LC_ALL to exercise byte mode.
+        std::env::set_var("LC_ALL", "C.UTF-8");
     }
 }
 


### PR DESCRIPTION
The original Rust implementation assummed a UTF-8 environment, as is common in modern systems.  This commit improves GNU sed compatibility by changing most processing to run on bytes rather than Rust's Unicode characters and strings. This change also improves the handling of binary files. The commit adds a simple POSIX-compatible locale configuration to support UTF-8 processing when specified. While at it, also fix script-specified file handling to take place through OsString.

The change fixes two failing GNU test suite cases.