### PR TITLE
Fix --posix to disable the GNU regular expression escapes

### DIFF
--- a/src/sed/compiler.rs
+++ b/src/sed/compiler.rs
@@ -468,7 +468,13 @@ fn compile_address(
             } else {
                 RegexMode::Basic
             };
-            let re = parse_regex_for_mode(lines, line, regex_mode, context.character_mode)?;
+            let re = parse_regex_for_mode(
+                lines,
+                line,
+                regex_mode,
+                context.character_mode,
+                context.posix,
+            )?;
             // Skip over delimiter
             line.advance();
 
@@ -847,7 +853,13 @@ fn compile_subst_command(
     } else {
         RegexMode::Basic
     };
-    let pattern = parse_regex_for_mode(lines, line, regex_mode, context.character_mode)?;
+    let pattern = parse_regex_for_mode(
+        lines,
+        line,
+        regex_mode,
+        context.character_mode,
+        context.posix,
+    )?;
     let mut subst = Box::new(Substitution::default());
 
     subst.replacement = compile_replacement(lines, line, context.character_mode)?;

--- a/src/sed/delimited_parser.rs
+++ b/src/sed/delimited_parser.rs
@@ -359,15 +359,27 @@ pub fn parse_regex(
     line: &mut ScriptCharProvider,
     regex_mode: RegexMode,
 ) -> UResult<Vec<u8>> {
-    parse_regex_for_mode(lines, line, regex_mode, CharacterMode::Utf8)
+    parse_regex_for_mode(lines, line, regex_mode, CharacterMode::Utf8, false)
+}
+
+/// Return true if a backslash followed by `c` is a GNU regular expression
+/// extension, which under --posix stands for the literal character `c`.
+fn is_gnu_regex_escape(c: char) -> bool {
+    matches!(
+        c,
+        '?' | '+' | '|' | 'w' | 'W' | 's' | 'S' | 'b' | 'B' | '<' | '>' | '`' | '\''
+    )
 }
 
 /// Parse a regular expression according to the current character mode.
+/// Under `posix` the GNU regular expression extensions are disabled, with each
+/// one standing for the literal character that follows its backslash.
 pub fn parse_regex_for_mode(
     lines: &ScriptLineProvider,
     line: &mut ScriptCharProvider,
     regex_mode: RegexMode,
     character_mode: CharacterMode,
+    posix: bool,
 ) -> UResult<Vec<u8>> {
     let delimiter = scan_delimiter(lines, line)?;
     let mut result = Vec::new();
@@ -385,6 +397,17 @@ pub fn parse_regex_for_mode(
                 }
                 if line.current() == delimiter {
                     // Push escaped delimiter
+                    result.push(line.current_byte());
+                    line.advance();
+                    continue;
+                }
+                if posix && is_gnu_regex_escape(line.current()) {
+                    // ? + | must keep their backslash to remain literals.
+                    if matches!(regex_mode, RegexMode::Extended)
+                        && matches!(line.current(), '?' | '+' | '|')
+                    {
+                        result.push(b'\\');
+                    }
                     result.push(line.current_byte());
                     line.advance();
                     continue;
@@ -1252,6 +1275,59 @@ mod tests {
         let parsed = parse_regex(&lines, &mut line, RegexMode::Basic).unwrap();
         assert_eq!(parsed, br"\(\\");
         assert_eq!(line.current(), '/');
+    }
+
+    // parse_regex_for_mode: GNU extensions under --posix
+    #[test]
+    fn test_posix_bre_emits_bare_characters() {
+        // bre_to_ere() escapes the ERE metacharacters, so they are left bare.
+        let (lines, mut line) = make_providers(r"/0\?a\+b\|/");
+        let parsed = parse_regex_for_mode(
+            &lines,
+            &mut line,
+            RegexMode::Basic,
+            CharacterMode::Utf8,
+            true,
+        )
+        .unwrap();
+        assert_eq!(parsed, b"0?a+b|");
+
+        let (lines, mut line) = make_providers(r"/\w\s\b\<\`/");
+        let parsed = parse_regex_for_mode(
+            &lines,
+            &mut line,
+            RegexMode::Basic,
+            CharacterMode::Utf8,
+            true,
+        )
+        .unwrap();
+        assert_eq!(parsed, b"wsb<`");
+    }
+
+    #[test]
+    fn test_posix_ere_keeps_metacharacters_escaped() {
+        // In EREs \? \+ \| are already literals, so the backslash stays.
+        let (lines, mut line) = make_providers(r"/a\?b\+c\|/");
+        let parsed = parse_regex_for_mode(
+            &lines,
+            &mut line,
+            RegexMode::Extended,
+            CharacterMode::Utf8,
+            true,
+        )
+        .unwrap();
+        assert_eq!(parsed, br"a\?b\+c\|");
+
+        let (lines, mut line) = make_providers(r"/\w\s\b/");
+        let parsed = parse_regex_for_mode(
+            &lines,
+            &mut line,
+            RegexMode::Extended,
+            CharacterMode::Utf8,
+            true,
+        )
+        .unwrap();
+        assert_eq!(parsed, b"wsb");
     }
 
     // validate_quantifier_structure

--- a/tests/by-util/test_sed.rs
+++ b/tests/by-util/test_sed.rs
@@ -809,6 +809,73 @@ fn test_subst_e_flag_no_match_no_exec() {
 }
 
 ////////////////////////////////////////////////////////////
+// GNU regular expression extensions and --posix
+// Under --posix the GNU extensions \? \+ \| \w \W \s \S \b \B \< \> \` \'
+// stand for the literal character following the backslash.
+
+#[test]
+fn test_posix_disables_gnu_bre_operators() {
+    // The non-POSIX behavior is covered by the subst_quantifier_* and
+    // subst_alternation_operator tests above.
+    new_ucmd!()
+        .args(&["--posix", "-e", r"/0\?/d"])
+        .pipe_in("a\nb\n0?\n")
+        .succeeds()
+        .stdout_is("a\nb\n");
+    new_ucmd!()
+        .args(&["--posix", "-e", r"/a\+/d"])
+        .pipe_in("a\nb\na+\n")
+        .succeeds()
+        .stdout_is("a\nb\n");
+    new_ucmd!()
+        .args(&["--posix", "-e", r"/a\|b/d"])
+        .pipe_in("a\nb\na|b\n")
+        .succeeds()
+        .stdout_is("a\nb\n");
+}
+
+#[test]
+fn test_posix_disables_gnu_character_classes() {
+    new_ucmd!()
+        .args(&["--posix", "-e", r"/\w/d"])
+        .pipe_in("a\nb\nw\n")
+        .succeeds()
+        .stdout_is("a\nb\n");
+    new_ucmd!()
+        .args(&["-e", r"/\w/d"])
+        .pipe_in("a\nb\nw\n")
+        .succeeds()
+        .stdout_is("");
+}
+
+#[test]
+fn test_posix_disables_gnu_extensions_in_ere() {
+    new_ucmd!()
+        .args(&["--posix", "-E", "-e", r"/\w/d"])
+        .pipe_in("aw\nx\n")
+        .succeeds()
+        .stdout_is("x\n");
+    new_ucmd!()
+        .args(&["-E", "-e", r"/\w/d"])
+        .pipe_in("aw\nx\n")
+        .succeeds()
+        .stdout_is("");
+}
+
+#[test]
+fn test_posix_keeps_posix_regex_constructs() {
+    // Groups, quantifiers, operators and character escapes are POSIX,
+    // so --posix must leave them alone
+    for script in [r"s/\(a\)a/X/", r"s/a\{2\}/X/", r"s/a\x61/X/"] {
+        new_ucmd!()
+            .args(&["--posix", "-e", script])
+            .pipe_in("aab\n")
+            .succeeds()
+            .stdout_is("Xb\n");
+    }
+}
+
+////////////////////////////////////////////////////////////
 // e command (execute)
 // The with-argument form writes the shell's raw, unmodified output to the
 // stream, so its byte-exact terminator differs by platform: LF from /bin/sh


### PR DESCRIPTION
Fixes #542 

Under `--posix`, GNU sed treats the GNU regular expression escapes as the literal character that follows the backslash. These are the operators `\?`, `\+` and `\|`, the character classes `\w`, `\W`, `\s` and `\S`, and the empty-width matches `\b`, `\B`, `\<`, `\>`, `` \` `` and `\'`.

`parse_regex_for_mode()` now takes a POSIX parameter and emits the literal character for these escapes. The check comes before `parse_char_escape()`, otherwise `\b` is decoded as a backspace.

### BRE and ERE

The two modes need the opposite spelling of the same literal:

- In BRE the character is emitted bare, because `bre_to_ere()` escapes the ERE metacharacters afterwards. Emitting `\?` would make `bre_to_ere()` turn it back into the operator.
- In ERE `\?`, `\+` and `\|` keep their backslash, since a backslash is already what makes them literals there. Emitting them bare would make them operators.

The remaining escapes are letters and punctuation with no meaning of their own, so they are emitted bare in both modes.